### PR TITLE
Setup DEBUG mode

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,9 @@ jobs:
           ./install.sh ../
         working-directory: agbcc
 
-      - name: Compare
+      - name: Build
+        env:
+          COMPARE: 0
         run: make -j${nproc} all syms
 
       - name: Modern

--- a/Makefile
+++ b/Makefile
@@ -63,7 +63,7 @@ else
   CPP := $(PREFIX)cpp
 endif
 
-ROM_NAME := pokeemerald.gba
+ROM_NAME := pokemon_emerald_refined.gba
 ELF_NAME := $(ROM_NAME:.gba=.elf)
 MAP_NAME := $(ROM_NAME:.gba=.map)
 OBJ_DIR_NAME := build/emerald

--- a/data/event_scripts.s
+++ b/data/event_scripts.s
@@ -577,6 +577,8 @@ gStdScripts_End::
 	.include "data/scripts/new_game.inc"
 	.include "data/scripts/hall_of_fame.inc"
 
+	.include "data/scripts/debug.inc"
+
 EventScript_WhiteOut::
 	call EverGrandeCity_HallOfFame_EventScript_ResetEliteFour
 	goto EventScript_ResetMrBriney

--- a/data/scripts/debug.inc
+++ b/data/scripts/debug.inc
@@ -1,0 +1,67 @@
+Debug_ShowFieldMessageStringVar4::
+	special ShowFieldMessageStringVar4
+	waitmessage
+	waitbuttonpress
+	releaseall
+	end
+
+Debug_CheatStart::
+	lockall
+	setflag FLAG_SYS_POKEMON_GET
+	setflag FLAG_RESCUED_BIRCH
+	setflag FLAG_HIDE_ROUTE_101_BIRCH_ZIGZAGOON_BATTLE
+	setflag FLAG_ADVENTURE_STARTED
+	clearflag FLAG_HIDE_LITTLEROOT_TOWN_BIRCHS_LAB_BIRCH
+	setflag FLAG_HIDE_ROUTE_101_BIRCH_STARTERS_BAG
+	setvar VAR_BIRCH_LAB_STATE, 2
+	setvar VAR_ROUTE101_STATE, 3
+	givemon SPECIES_TREECKO, 20, ITEM_NONE
+	givemon SPECIES_TORCHIC, 20, ITEM_NONE
+	givemon SPECIES_MUDKIP, 20, ITEM_NONE
+	setflag FLAG_SYS_POKEDEX_GET
+	special SetUnlockedPokedexFlags
+	setflag FLAG_RECEIVED_POKEDEX_FROM_BIRCH
+	setvar VAR_CABLE_CLUB_TUTORIAL_STATE, 1
+	setflag FLAG_SYS_NATIONAL_DEX
+	special EnableNationalPokedex
+	setflag FLAG_RECEIVED_RUNNING_SHOES
+	setflag FLAG_SYS_B_DASH
+	setvar VAR_LITTLEROOT_TOWN_STATE, 4 @ 4: Received Running Shoes
+	setvar VAR_LITTLEROOT_INTRO_STATE, 7 @ 7: Told to go meet rival
+	setvar VAR_LITTLEROOT_HOUSES_STATE_BRENDAN, 2 @ 2: Met Rival's Mom (and is corresponding gender)
+	setvar VAR_LITTLEROOT_HOUSES_STATE_MAY, 2 @ 2: Met Rival's Mom (and is corresponding gender)
+	setvar VAR_LITTLEROOT_RIVAL_STATE, 4 @ 4: Received Pokedex
+	setflag FLAG_RECEIVED_BIKE
+	additem ITEM_ACRO_BIKE
+	setvar VAR_BRINEY_HOUSE_STATE, 1
+	setvar VAR_ROUTE116_STATE, 2
+	setflag FLAG_HIDE_ROUTE_116_MR_BRINEY
+	clearflag FLAG_HIDE_BRINEYS_HOUSE_MR_BRINEY
+	clearflag FLAG_HIDE_BRINEYS_HOUSE_PEEKO
+	closemessage
+	release
+	end
+
+Debug_Script_1::
+	end
+
+Debug_Script_2::
+	end
+
+Debug_Script_3::
+	end
+
+Debug_Script_4::
+	end
+
+Debug_Script_5::
+	end
+
+Debug_Script_6::
+	end
+
+Debug_Script_7::
+	end
+
+Debug_Script_8::
+	end

--- a/gflib/string_util.c
+++ b/gflib/string_util.c
@@ -332,6 +332,66 @@ u8 *ConvertIntToHexStringN(u8 *dest, s32 value, enum StringConvertMode mode, u8 
     return dest;
 }
 
+u8 *ConvertUIntToHexStringN(u8 *dest, u32 value, enum StringConvertMode mode, u8 n)
+{
+    enum { WAITING_FOR_NONZERO_DIGIT, WRITING_DIGITS, WRITING_SPACES } state;
+    u8 i;
+    s32 powerOfSixteen;
+    s32 largestPowerOfSixteen = 1;
+
+    for (i = 1; i < n; i++)
+        largestPowerOfSixteen *= 16;
+
+    state = WAITING_FOR_NONZERO_DIGIT;
+
+    if (mode == STR_CONV_MODE_RIGHT_ALIGN)
+        state = WRITING_SPACES;
+
+    if (mode == STR_CONV_MODE_LEADING_ZEROS)
+        state = WRITING_DIGITS;
+
+    for (powerOfSixteen = largestPowerOfSixteen; powerOfSixteen > 0; powerOfSixteen /= 16)
+    {
+        u8 c;
+        u32 digit = value / powerOfSixteen;
+        u32 temp = value % powerOfSixteen;
+
+        if (state == WRITING_DIGITS)
+        {
+            char *out = dest++;
+
+            if (digit <= 0xF)
+                c = sDigits[digit];
+            else
+                c = CHAR_QUESTION_MARK;
+
+            *out = c;
+        }
+        else if (digit != 0 || powerOfSixteen == 1)
+        {
+            char *out;
+            state = WRITING_DIGITS;
+            out = dest++;
+
+            if (digit <= 0xF)
+                c = sDigits[digit];
+            else
+                c = CHAR_QUESTION_MARK;
+
+            *out = c;
+        }
+        else if (state == WRITING_SPACES)
+        {
+            *dest++ = 0x77;
+        }
+
+        value = temp;
+    }
+
+    *dest = EOS;
+    return dest;
+}
+
 u8 *StringExpandPlaceholders(u8 *dest, const u8 *src)
 {
     for (;;)

--- a/gflib/string_util.h
+++ b/gflib/string_util.h
@@ -27,6 +27,7 @@ bool8 IsStringLengthAtLeast(const u8 *str, s32 n);
 u8 *ConvertIntToDecimalStringN(u8 *dest, s32 value, enum StringConvertMode mode, u8 n);
 u8 *ConvertUIntToDecimalStringN(u8 *dest, u32 value, enum StringConvertMode mode, u8 n);
 u8 *ConvertIntToHexStringN(u8 *dest, s32 value, enum StringConvertMode mode, u8 n);
+u8 *ConvertUIntToHexStringN(u8 *dest, u32 value, enum StringConvertMode mode, u8 n);
 u8 *StringExpandPlaceholders(u8 *dest, const u8 *src);
 u8 *StringBraille(u8 *dest, const u8 *src);
 const u8 *GetExpandedPlaceholder(u32 id);

--- a/include/battle_setup.h
+++ b/include/battle_setup.h
@@ -64,4 +64,7 @@ bool8 IsTrainerReadyForRematch(void);
 void ShouldTryGetTrainerScript(void);
 u16 CountBattledRematchTeams(u16 trainerId);
 
+void DoStandardWildBattle_Debug(void);
+void BattleSetup_StartTrainerBattle_Debug(void);
+
 #endif // GUARD_BATTLE_SETUP_H

--- a/include/config.h
+++ b/include/config.h
@@ -6,7 +6,7 @@
 // still has them in the ROM. This is because the developers forgot
 // to define NDEBUG before release, however this has been changed as
 // Ruby's actual debug build does not use the AGBPrint features.
-#define NDEBUG
+// #define NDEBUG
 
 // To enable printf debugging, comment out "#define NDEBUG". This allows
 // the various AGBPrint functions to be used. (See include/gba/isagbprint.h).

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -42,13 +42,13 @@
 #define TEMP_FLAGS_END   FLAG_TEMP_1F
 #define NUM_TEMP_FLAGS   (TEMP_FLAGS_END - TEMP_FLAGS_START + 1)
 
-#define FLAG_UNUSED_0x020    0x20 // Unused Flag
-#define FLAG_UNUSED_0x021    0x21 // Unused Flag
-#define FLAG_UNUSED_0x022    0x22 // Unused Flag
-#define FLAG_UNUSED_0x023    0x23 // Unused Flag
-#define FLAG_UNUSED_0x024    0x24 // Unused Flag
-#define FLAG_UNUSED_0x025    0x25 // Unused Flag
-#define FLAG_UNUSED_0x026    0x26 // Unused Flag
+#define FLAG_SYS_NO_COLLISION       0x20 // Unused Flag // DEBUG
+#define FLAG_SYS_NO_ENCOUNTER       0x21 // Unused Flag // DEBUG
+#define FLAG_SYS_NO_TRAINER_SEE     0x22 // Unused Flag // DEBUG
+#define FLAG_SYS_NO_BAG_USE         0x23 // Unused Flag // DEBUG
+#define FLAG_SYS_NO_CATCHING        0x24 // Unused Flag // DEBUG
+#define FLAG_SYS_PC_FROM_DEBUG_MENU 0x25 // Unused Flag // DEBUG
+#define FLAG_SYS_NO_BATTLE_DMG      0x26 // Unused Flag // DEBUG
 #define FLAG_UNUSED_0x027    0x27 // Unused Flag
 #define FLAG_UNUSED_0x028    0x28 // Unused Flag
 #define FLAG_UNUSED_0x029    0x29 // Unused Flag

--- a/include/constants/map_groups.h
+++ b/include/constants/map_groups.h
@@ -593,4 +593,6 @@
 
 #define MAP_GROUPS_COUNT 34
 
+// static const u8 MAP_GROUP_COUNT[] = {57, 5, 5, 6, 7, 8, 9, 7, 7, 14, 8, 17, 10, 23, 13, 15, 15, 2, 2, 2, 3, 1, 1, 1, 108, 61, 89, 2, 1, 13, 1, 1, 3, 1, 0};
+
 #endif // GUARD_CONSTANTS_MAP_GROUPS_H

--- a/include/constants/songs.h
+++ b/include/constants/songs.h
@@ -276,8 +276,10 @@
 #define SE_PIKE_CURTAIN_CLOSE       267 // SE_CURTAIN
 #define SE_PIKE_CURTAIN_OPEN        268 // SE_CURTAIN1
 #define SE_SUDOWOODO_SHAKE          269 // SE_USSOKI
+#define END_SE                      SE_SUDOWOODO_SHAKE
 
 // Music
+#define START_MUS                   350
 #define MUS_LITTLEROOT_TEST         350 // MUS_TETSUJI          // Unused, likely a test track.
 #define MUS_GSC_ROUTE38             351 // MUS_FIELD13          // Unused, likely a test track.
 #define MUS_CAUGHT                  352 // MUS_KACHI22
@@ -488,6 +490,7 @@
 #define MUS_RG_TRAINER_TOWER        556 // MUS_RG_T_TOWER
 #define MUS_RG_SLOW_PALLET          557 // MUS_RG_SLOWMASARA
 #define MUS_RG_TEACHY_TV_MENU       558 // MUS_RG_TVNOIZE
+#define END_MUS                     MUS_RG_TEACHY_TV_MENU
 
 #define PH_TRAP_BLEND               559
 #define PH_TRAP_HELD                560

--- a/include/debug.h
+++ b/include/debug.h
@@ -1,0 +1,17 @@
+#ifndef GUARD_DEBUG_H
+#define GUARD_DEBUG_H
+
+// Debug options
+#define TX_DEBUG_SYSTEM_ENABLE         TRUE               // Enables a overworld debug menu for changing flags, variables, giving pokemon and more, accessed by holding R and pressing START while in the overworld by default.
+#define TX_DEBUG_SYSTEM_HELD_KEYS      (R_BUTTON)         // The keys required to be held to open the debug menu.
+#define TX_DEBUG_SYSTEM_TRIGGER_EVENT  pressedStartButton // The event that opens the menu when holding the key(s) defined in DEBUG_SYSTEM_HELD_KEYS.
+#define TX_DEBUG_SYSTEM_IN_MENU        FALSE              // Replaces the overworld debug menu button combination with a start menu entry (above Pokédex).
+
+
+void Debug_ShowMainMenu(void);
+void Debug_ReShowBattleDebugMenu(void);
+
+extern EWRAM_DATA bool8 gIsDebugBattle;
+extern EWRAM_DATA u32 gDebugAIFlags;
+
+#endif // GUARD_DEBUG_H

--- a/include/debug_pokemon_creator.h
+++ b/include/debug_pokemon_creator.h
@@ -1,0 +1,10 @@
+#ifndef GUARD_DEBUG_POKEMON_CREATOR_H
+#define GUARD_DEBUG_POKEMON_CREATOR_H
+
+#define MODIFY_DIGITS_MAX 4
+
+void CB2_Debug_Pokemon(void);
+void DebugPkmCreator_Init(u8 mode, u8 index);
+
+
+#endif // GUARD_DEBUG_POKEMON_CREATOR_H

--- a/include/event_data.h
+++ b/include/event_data.h
@@ -20,10 +20,12 @@ void EnableResetRTC(void);
 bool32 CanResetRTC(void);
 u16 *GetVarPointer(u16 id);
 u16 VarGet(u16 id);
+u16 VarGetIfExist(u16 id);
 bool8 VarSet(u16 id, u16 value);
 u8 VarGetObjectEventGraphicsId(u8 id);
 u8 *GetFlagPointer(u16 id);
 u8 FlagSet(u16 id);
+u8 FlagToggle(u16 id);
 u8 FlagClear(u16 id);
 bool8 FlagGet(u16 id);
 

--- a/include/main_menu.h
+++ b/include/main_menu.h
@@ -3,5 +3,6 @@
 
 void CB2_InitMainMenu(void);
 void CreateYesNoMenuParameterized(u8 x, u8 y, u16 baseTileNum, u16 baseBlock, u8 yesNoPalNum, u8 winPalNum);
+void NewGameBirchSpeech_SetDefaultPlayerName(u8);
 
 #endif // GUARD_MAIN_MENU_H

--- a/include/pokemon.h
+++ b/include/pokemon.h
@@ -453,6 +453,7 @@ void SetMonData(struct Pokemon *mon, s32 field, const void *dataArg);
 void SetBoxMonData(struct BoxPokemon *boxMon, s32 field, const void *dataArg);
 void CopyMon(void *dest, void *src, size_t size);
 u8 GiveMonToPlayer(struct Pokemon *mon);
+u8 CopyMonToPC(struct Pokemon* mon);
 u8 CalculatePlayerPartyCount(void);
 u8 CalculateEnemyPartyCount(void);
 u8 GetMonsStateToDoubles(void);

--- a/include/pokemon_storage_system.h
+++ b/include/pokemon_storage_system.h
@@ -72,4 +72,6 @@ u8 *GetWaldaPhrasePtr(void);
 void SetWaldaPhrase(const u8 *src);
 bool32 IsWaldaPhraseEmpty(void);
 
+void EnterPokeStorage(u8 boxOption);
+
 #endif // GUARD_POKEMON_STORAGE_SYSTEM_H

--- a/include/region_map.h
+++ b/include/region_map.h
@@ -114,6 +114,7 @@ bool8 IsRegionMapZoomed(void);
 void TrySetPlayerIconBlink(void);
 void BlendRegionMap(u16 color, u32 coeff);
 void SetRegionMapDataForZoom(void);
+u8* GetMapName_HandleVersion(u8*, u16, u8);
 
 extern const struct RegionMapLocation gRegionMapEntries[];
 

--- a/include/wild_encounter.h
+++ b/include/wild_encounter.h
@@ -37,4 +37,6 @@ u16 GetLocalWildMon(bool8 *isWaterMon);
 u16 GetLocalWaterMon(void);
 bool8 UpdateRepelCounter(void);
 
+bool8 StandardWildEncounter_Debug(void);
+
 #endif // GUARD_WILD_ENCOUNTER_H

--- a/ld_script.ld
+++ b/ld_script.ld
@@ -107,6 +107,8 @@ SECTIONS {
         src/random.o(.text);
         src/util.o(.text);
         src/daycare.o(.text);
+        src/debug.o(.text);
+        src/debug_pokemon_creator.o(.text);
         src/egg_hatch.o(.text);
         src/battle_interface.o(.text);
         src/battle_anim_smokescreen.o(.text);
@@ -493,6 +495,8 @@ SECTIONS {
         src/trig.o(.rodata);
         src/util.o(.rodata);
         src/daycare.o(.rodata);
+        src/debug.o(.rodata);
+        src/debug_pokemon_creator.o(.rodata);
         src/egg_hatch.o(.rodata);
         src/battle_gfx_sfx_util.o(.rodata);
         src/battle_interface.o(.rodata);

--- a/src/battle_ai_script_commands.c
+++ b/src/battle_ai_script_commands.c
@@ -375,6 +375,11 @@ void BattleAI_SetupAIData(u8 defaultScoreMoves)
     else
        AI_THINKING_STRUCT->aiFlags = gTrainers[gTrainerBattleOpponent_A].aiFlags;
 
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    if (gIsDebugBattle)
+        AI_THINKING_STRUCT->aiFlags = gDebugAIFlags;
+#endif
+
     if (gBattleTypeFlags & BATTLE_TYPE_DOUBLE)
         AI_THINKING_STRUCT->aiFlags |= AI_SCRIPT_DOUBLE_BATTLE; // act smart in doubles and don't attack your partner
 }

--- a/src/battle_main.c
+++ b/src/battle_main.c
@@ -15,6 +15,7 @@
 #include "berry.h"
 #include "bg.h"
 #include "data.h"
+#include "debug.h"
 #include "decompress.h"
 #include "dma3.h"
 #include "event_data.h"
@@ -669,7 +670,14 @@ static void CB2_InitBattleInternal(void)
     gBattle_BG3_X = 0;
     gBattle_BG3_Y = 0;
 
+#if TX_DEBUG_SYSTEM_ENABLE == FALSE 
+
     gBattleTerrain = BattleSetup_GetTerrainId();
+#else
+    if (!gIsDebugBattle)
+        gBattleTerrain = BattleSetup_GetTerrainId();
+#endif
+
     if (gBattleTypeFlags & BATTLE_TYPE_RECORDED)
         gBattleTerrain = BATTLE_TERRAIN_BUILDING;
 
@@ -692,6 +700,7 @@ static void CB2_InitBattleInternal(void)
     else
         SetMainCallback2(CB2_HandleStartBattle);
 
+#if TX_DEBUG_SYSTEM_ENABLE == FALSE
     if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED)))
     {
         CreateNPCTrainerParty(&gEnemyParty[0], gTrainerBattleOpponent_A, TRUE);
@@ -699,6 +708,18 @@ static void CB2_InitBattleInternal(void)
             CreateNPCTrainerParty(&gEnemyParty[PARTY_SIZE / 2], gTrainerBattleOpponent_B, FALSE);
         SetWildMonHeldItem();
     }
+#else
+    if (!gIsDebugBattle)
+    {
+        if (!(gBattleTypeFlags & (BATTLE_TYPE_LINK | BATTLE_TYPE_RECORDED)))
+        {
+            CreateNPCTrainerParty(&gEnemyParty[0], gTrainerBattleOpponent_A, TRUE);
+            if (gBattleTypeFlags & BATTLE_TYPE_TWO_OPPONENTS)
+                CreateNPCTrainerParty(&gEnemyParty[PARTY_SIZE / 2], gTrainerBattleOpponent_B, FALSE);
+            SetWildMonHeldItem();
+        }
+    }
+#endif
 
     gMain.inBattle = TRUE;
     gSaveBlock2Ptr->frontier.disableRecordBattle = FALSE;
@@ -4191,6 +4212,20 @@ static void HandleTurnActionSelectionState(void)
                     }
                     break;
                 case B_ACTION_USE_ITEM:
+                #if TX_DEBUG_SYSTEM_ENABLE == TRUE
+                    if (FlagGet(FLAG_SYS_NO_BAG_USE) || gBattleTypeFlags & (BATTLE_TYPE_LINK
+                                            | BATTLE_TYPE_FRONTIER_NO_PYRAMID
+                                            | BATTLE_TYPE_EREADER_TRAINER
+                                            | BATTLE_TYPE_RECORDED_LINK))
+                    {
+                        RecordedBattle_ClearBattlerAction(gActiveBattler, 1);
+                        gSelectionBattleScripts[gActiveBattler] = BattleScript_ActionSelectionItemsCantBeUsed;
+                        gBattleCommunication[gActiveBattler] = STATE_SELECTION_SCRIPT;
+                        *(gBattleStruct->selectionScriptFinished + gActiveBattler) = FALSE;
+                        *(gBattleStruct->stateIdAfterSelScript + gActiveBattler) = STATE_BEFORE_ACTION_CHOSEN;
+                        return;
+                    }
+                #endif
                     if (gBattleTypeFlags & (BATTLE_TYPE_LINK
                                             | BATTLE_TYPE_FRONTIER_NO_PYRAMID
                                             | BATTLE_TYPE_EREADER_TRAINER

--- a/src/battle_script_commands.c
+++ b/src/battle_script_commands.c
@@ -51,6 +51,8 @@
 #include "constants/rgb.h"
 #include "constants/songs.h"
 #include "constants/trainers.h"
+#include "constants/flags.h"
+#include "debug.h"
 
 extern const u8 *const gBattleScriptsForMoveEffects[];
 
@@ -1802,6 +1804,14 @@ static void Cmd_waitanimation(void)
 
 static void Cmd_healthbarupdate(void)
 {
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    u8 side = GetBattlerSide(gBattlerTarget);
+    if (FlagGet(FLAG_SYS_NO_BATTLE_DMG) && side == B_SIDE_PLAYER)
+    {
+        gMoveResultFlags |= MOVE_RESULT_NO_EFFECT;
+    }
+#endif
+
     if (gBattleControllerExecFlags)
         return;
 

--- a/src/battle_setup.c
+++ b/src/battle_setup.c
@@ -382,6 +382,41 @@ static void CreateBattleStartTask(u8 transition, u16 song)
     PlayMapChosenOrBattleBGM(song);
 }
 
+static void Task_BattleStart_Debug(u8 taskId)
+{
+    s16 *data = gTasks[taskId].data;
+
+    switch (tState)
+    {
+    case 0:
+        if (!FldEffPoison_IsActive()) // is poison not active?
+        {
+            BattleTransition_StartOnField(tTransition);
+            ClearMirageTowerPulseBlendEffect();
+            tState++; // go to case 1.
+        }
+        break;
+    case 1:
+        if (IsBattleTransitionDone() == TRUE)
+        {
+            CleanupOverworldWindowsAndTilemaps();
+            SetMainCallback2(CB2_InitBattle);
+            RestartWildEncounterImmunitySteps();
+            ClearPoisonStepCounter();
+            DestroyTask(taskId);
+        }
+        break;
+    }
+}
+
+static void CreateBattleStartTask_Debug(u8 transition, u16 song)
+{
+    u8 taskId = CreateTask(Task_BattleStart_Debug, 1);
+
+    gTasks[taskId].tTransition = transition;
+    PlayMapChosenOrBattleBGM(song);
+}
+
 #undef tState
 #undef tTransition
 
@@ -415,6 +450,25 @@ static void DoStandardWildBattle(void)
     IncrementGameStat(GAME_STAT_WILD_BATTLES);
     IncrementDailyWildBattles();
     TryUpdateGymLeaderRematchFromWild();
+}
+
+void DoStandardWildBattle_Debug(void)
+{
+    LockPlayerFieldControls();
+    FreezeObjectEvents();
+    StopPlayerAvatar();
+    gMain.savedCallback = CB2_EndWildBattle;
+    gBattleTypeFlags = 0;
+    if (InBattlePyramid())
+    {
+        VarSet(VAR_TEMP_E, 0);
+        gBattleTypeFlags |= BATTLE_TYPE_PYRAMID;
+    }
+    CreateBattleStartTask_Debug(GetWildBattleTransition(), 0);
+    //IncrementGameStat(GAME_STAT_TOTAL_BATTLES);
+    //IncrementGameStat(GAME_STAT_WILD_BATTLES);
+    //IncrementDailyWildBattles();
+    //TryUpdateGymLeaderRematchFromWild();
 }
 
 void BattleSetup_StartRoamerBattle(void)
@@ -1319,6 +1373,19 @@ void BattleSetup_StartTrainerBattle(void)
         DoBattlePyramidTrainerHillBattle();
     else
         DoTrainerBattle();
+
+    ScriptContext_Stop();
+}
+
+void BattleSetup_StartTrainerBattle_Debug(void)
+{
+    sNoOfPossibleTrainerRetScripts = gNoOfApproachingTrainers;
+    gNoOfApproachingTrainers = 0;
+    sShouldCheckTrainerBScript = FALSE;
+    gWhichTrainerToFaceAfterBattle = 0;
+    gMain.savedCallback = CB2_EndTrainerBattle;
+
+    CreateBattleStartTask_Debug(GetWildBattleTransition(), 0);
 
     ScriptContext_Stop();
 }

--- a/src/debug.c
+++ b/src/debug.c
@@ -1,0 +1,4541 @@
+//CREDITS
+//TheXaman:             https://github.com/TheXaman/pokeemerald/tree/tx_debug_system
+//CODE USED FROM:
+//ketsuban:             https://github.com/pret/pokeemerald/wiki/Add-a-debug-menu
+//Pyredrid:             https://github.com/Pyredrid/pokeemerald/tree/debugmenu
+//AsparagusEduardo:     https://github.com/AsparagusEduardo/pokeemerald/tree/InfusedEmerald_v2
+//Ghoulslash:           https://github.com/ghoulslash/pokeemerald
+//Jaizu:                https://jaizu.moe/
+#include "global.h"
+#include "battle.h"
+#include "battle_setup.h"
+#include "coins.h"
+#include "credits.h"
+#include "data.h"
+#include "daycare.h"
+#include "debug.h"
+#include "debug_pokemon_creator.h"
+#include "event_data.h"
+#include "event_object_movement.h"
+#include "event_scripts.h"
+#include "field_message_box.h"
+#include "field_screen_effect.h"
+#include "field_weather.h"
+#include "international_string_util.h"
+#include "item.h"
+#include "item_icon.h"
+#include "list_menu.h"
+#include "m4a.h"
+#include "main.h"
+#include "main_menu.h"
+#include "malloc.h"
+#include "map_name_popup.h"
+#include "menu.h"
+#include "money.h"
+#include "naming_screen.h"
+#include "new_game.h"
+#include "overworld.h"
+#include "palette.h"
+#include "party_menu.h"
+#include "pokedex.h"
+#include "pokemon.h"
+#include "pokemon_icon.h"
+#include "pokemon_storage_system.h"
+#include "random.h"
+#include "region_map.h"
+#include "script.h"
+#include "script_pokemon_util.h"
+#include "sound.h"
+#include "strings.h"
+#include "string_util.h"
+#include "task.h"
+#include "pokemon_summary_screen.h"
+#include "wild_encounter.h"
+#include "constants/abilities.h"
+#include "constants/battle_frontier.h"
+#include "constants/flags.h"
+#include "constants/items.h"
+#include "constants/map_groups.h"
+#include "constants/rgb.h"
+#include "constants/songs.h"
+#include "constants/species.h"
+#include "constants/weather.h"
+
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+// *******************************
+// Enums
+enum { // Main
+    DEBUG_MENU_ITEM_UTILITIES,
+    DEBUG_MENU_ITEM_SCRIPTS,
+    DEBUG_MENU_ITEM_FLAGVAR,
+    DEBUG_MENU_ITEM_BATTLE,
+    DEBUG_MENU_ITEM_GIVE,
+    DEBUG_MENU_ITEM_POKEMON_CREATOR,
+    DEBUG_MENU_ITEM_FILL,
+    DEBUG_MENU_ITEM_SOUND,
+    DEBUG_MENU_ITEM_ACCESS_PC,
+    DEBUG_MENU_ITEM_CANCEL
+};
+enum { // Util
+    DEBUG_UTIL_MENU_ITEM_HEAL_PARTY,
+    DEBUG_UTIL_MENU_ITEM_FLY,
+    DEBUG_UTIL_MENU_ITEM_WARP,
+    DEBUG_UTIL_MENU_ITEM_POISON_MONS,
+    DEBUG_UTIL_MENU_ITEM_SAVEBLOCK,
+    DEBUG_UTIL_MENU_ITEM_WEATHER,
+    DEBUG_UTIL_MENU_ITEM_CHECKWALLCLOCK,
+    DEBUG_UTIL_MENU_ITEM_SETWALLCLOCK,
+    DEBUG_UTIL_MENU_ITEM_WATCHCREDITS,
+    DEBUG_UTIL_MENU_ITEM_TRAINER_NAME,
+    DEBUG_UTIL_MENU_ITEM_TRAINER_GENDER,
+    DEBUG_UTIL_MENU_ITEM_TRAINER_ID,
+    DEBUG_UTIL_MENU_ITEM_CHEAT,
+};
+enum { // Scripts
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_1,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_2,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_3,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_4,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_5,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_6,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_7,
+    DEBUG_UTIL_MENU_ITEM_SCRIPT_8,
+};
+enum { // Flags and Vars
+    DEBUG_FLAGVAR_MENU_ITEM_FLAGS,
+    DEBUG_FLAGVAR_MENU_ITEM_VARS,
+    DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_ALL,
+    DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_RESET,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKEDEX,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_NATDEX,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKENAV,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_RUN_SHOES,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_LOCATIONS,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BADGES_ALL,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_FRONTIER_PASS,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BATTLE_DMG,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_COLISSION,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_ENCOUNTER,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_TRAINER_SEE,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BAG_USE,
+    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_CATCHING,
+};
+enum { // Battle 0 Type
+    DEBUG_BATTLE_0_MENU_ITEM_WILD,
+#ifdef BATTLE_ENGINE
+    DEBUG_BATTLE_0_MENU_ITEM_WILD_DOUBLE,
+#endif
+    DEBUG_BATTLE_0_MENU_ITEM_SINGLE,
+    DEBUG_BATTLE_0_MENU_ITEM_DOUBLE,
+    DEBUG_BATTLE_0_MENU_ITEM_MULTI,
+};
+enum { // Battle 1 AI FLags
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_00,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_01,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_02,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_03,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_04,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_05,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_06,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_07,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_08,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_09,
+#ifdef BATTLE_ENGINE
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_10,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_11,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_12,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_13,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_14,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_15,
+    DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_16,
+#endif
+    DEBUG_BATTLE_1_MENU_ITEM_CONTINUE,
+};
+enum { // Battle 2 Terrain
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_0,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_1,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_2,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_3,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_4,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_5,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_6,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_7,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_8,   
+    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_9,
+};   
+enum { // Give
+    DEBUG_GIVE_MENU_ITEM_ITEM_X,
+    DEBUG_GIVE_MENU_ITEM_ALLTMS,
+    DEBUG_GIVE_MENU_ITEM_POKEMON_SIMPLE,
+    DEBUG_GIVE_MENU_ITEM_POKEMON_COMPLEX,
+    DEBUG_GIVE_MENU_ITEM_MAX_MONEY,
+    DEBUG_GIVE_MENU_ITEM_MAX_COINS,
+    DEBUG_GIVE_MENU_ITEM_MAX_BATTLE_POINTS,
+    DEBUG_GIVE_MENU_ITEM_DAYCARE_EGG,
+};
+enum {
+    DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_ADD,               // Add to party
+    DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_EDIT,              // Edit party
+    DEBUG_PKM_CREATOR_MENU_ITEM_PC_EDIT,                 // Edit PC Box
+    DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT,        // Edit enemy party (usable as a sandbox)
+    DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT_DEBUG,  // Edit enemy party for debug battle
+    DEBUG_PKM_CREATOR_MENU_ITEM_DEBUG_EDIT,              // Edit party for debug battle
+    DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_ADD,         // Add to enemy party (Unused)
+    DEBUG_PKM_CREATOR_MENU_ITEM_TESTING,                 // Testing mode (Dont alter parties)
+    DEBUG_PKM_CREATOR_MENU_ITEM_TESTING_COPY,            // Testing mode (use first mon as template)
+};
+enum { // Give Fill
+    DEBUG_FILL_MENU_ITEM_PC_BOXES_FAST,
+    DEBUG_FILL_MENU_ITEM_PC_BOXES_SLOW,
+    DEBUG_FILL_MENU_ITEM_PC_ITEMS,
+    DEBUG_FILL_MENU_ITEM_POCKET_ITEMS,
+    DEBUG_FILL_MENU_ITEM_POCKET_BALLS,
+    DEBUG_FILL_MENU_ITEM_POCKET_TMHM,
+    DEBUG_FILL_MENU_ITEM_POCKET_BERRIES,
+    DEBUG_FILL_MENU_ITEM_POCKET_KEY_ITEMS,
+};
+enum { //Sound
+    DEBUG_SOUND_MENU_ITEM_SE,
+    DEBUG_SOUND_MENU_ITEM_MUS,
+};
+
+
+// *******************************
+// Constants
+#define DEBUG_MENU_WIDTH_MAIN 16
+#define DEBUG_MENU_HEIGHT_MAIN 9
+
+#define DEBUG_MENU_WIDTH_EXTRA 10
+#define DEBUG_MENU_HEIGHT_EXTRA 4
+
+#define DEBUG_MENU_WIDTH_WEATHER 15
+#define DEBUG_MENU_HEIGHT_WEATHER 3
+
+#define DEBUG_MENU_WIDTH_SOUND 20
+#define DEBUG_MENU_HEIGHT_SOUND 6
+
+#define DEBUG_MENU_WIDTH_FLAGVAR 4
+#define DEBUG_MENU_HEIGHT_FLAGVAR 2
+
+#define DEBUG_NUMBER_DIGITS_FLAGS 4
+#define DEBUG_NUMBER_DIGITS_VARIABLES 5
+#define DEBUG_NUMBER_DIGITS_VARIABLE_VALUE 5
+#define DEBUG_NUMBER_DIGITS_ITEMS 4
+#define DEBUG_NUMBER_DIGITS_ITEM_QUANTITY 2
+
+#define DEBUG_NUMBER_ICON_X 210
+#define DEBUG_NUMBER_ICON_Y 50
+
+// *******************************
+struct DebugMonData
+{
+    u16 mon_speciesId;
+    u8  mon_level;
+    u8  isShiny;
+    u16 mon_natureId;
+    u16 mon_abilityNum;
+    u8  mon_iv_hp;
+    u8  mon_iv_atk;
+    u8  mon_iv_def;
+    u8  mon_iv_speed;
+    u8  mon_iv_satk;
+    u8  mon_iv_sdef;
+    u16 mon_move_0;
+    u16 mon_move_1;
+    u16 mon_move_2;
+    u16 mon_move_3;
+};
+
+struct DebugMenuListData
+{
+    struct ListMenuItem listItems[20 + 1];
+    u8 itemNames[PC_ITEMS_COUNT + 1][26];
+    u8 listId;
+};
+
+struct DebugBattleData
+{
+    u8 submenu;
+    u8 battleType;
+    u8 battleTerrain;
+#ifdef BATTLE_ENGINE
+    bool8 aiFlags[17];
+#else
+    bool8 aiFlags[10];
+#endif
+};
+
+// EWRAM
+static EWRAM_DATA struct DebugMonData *sDebugMonData = NULL;
+static EWRAM_DATA struct DebugMenuListData *sDebugMenuListData = NULL;
+static EWRAM_DATA struct DebugBattleData *sDebugBattleData = NULL;
+EWRAM_DATA bool8 gIsDebugBattle = FALSE;
+EWRAM_DATA u32 gDebugAIFlags = 0;
+
+// *******************************
+// Define functions
+static void Debug_ReShowMainMenu(void);
+static u8 Debug_ShowMenu(void (*HandleInput)(u8), struct ListMenuTemplate LMtemplate);
+static void Debug_DestroyMenu(u8 taskId);
+static void Debug_DestroyMenu_Full(u8 taskId);
+static void DebugAction_Cancel(u8 taskId);
+static void DebugAction_DestroyExtraWindow(u8 taskId);
+static void DebugTask_HandleMenuInput(u8 taskId, void (*HandleInput)(u8));
+static void Debug_InitDebugBattleData(void);
+static void Debug_RefreshListMenu(u8 taskId);
+static void Debug_RedrawListMenu(u8 taskId);
+
+static void DebugAction_Util_Script_1(u8 taskId);
+static void DebugAction_Util_Script_2(u8 taskId);
+static void DebugAction_Util_Script_3(u8 taskId);
+static void DebugAction_Util_Script_4(u8 taskId);
+static void DebugAction_Util_Script_5(u8 taskId);
+static void DebugAction_Util_Script_6(u8 taskId);
+static void DebugAction_Util_Script_7(u8 taskId);
+static void DebugAction_Util_Script_8(u8 taskId);
+
+static void DebugAction_OpenUtilitiesMenu(u8 taskId);
+static void DebugAction_OpenScriptsMenu(u8 taskId);
+static void DebugAction_OpenFlagsVarsMenu(u8 taskId);
+static void DebugAction_OpenBattleMenu(u8 taskId);
+static void DebugAction_OpenGiveMenu(u8 taskId);
+static void DebugAction_OpenPokemonCreator(u8 taskId);
+static void DebugAction_OpenFillMenu(u8 taskId);
+static void DebugAction_OpenSoundMenu(u8 taskId);
+static void DebugAction_AccessPC(u8 taskId);
+static void DebugTask_HandleMenuInput_Main(u8 taskId);
+static void DebugTask_HandleMenuInput_Utilities(u8 taskId);
+static void DebugTask_HandleMenuInput_Scripts(u8 taskId);
+static void DebugTask_HandleMenuInput_FlagsVars(u8 taskId);
+static void DebugTask_HandleMenuInput_Battle(u8 taskId);
+static void DebugTask_HandleMenuInput_Give(u8 taskId);
+static void DebugTask_HandleMenuInput_PkmCreator(u8 taskId);
+static void DebugTask_HandleMenuInput_Fill(u8 taskId);
+static void DebugTask_HandleMenuInput_Sound(u8 taskId);
+
+static void DebugAction_Util_HealParty(u8 taskId);
+static void DebugAction_Util_Fly(u8 taskId);
+static void DebugAction_Util_Warp_Warp(u8 taskId);
+static void DebugAction_Util_Warp_SelectMapGroup(u8 taskId);
+static void DebugAction_Util_Warp_SelectMap(u8 taskId);
+static void DebugAction_Util_Warp_SelectWarp(u8 taskId);
+static void DebugAction_FlagsVars_RunningShoes(u8 taskId);
+static void DebugAction_Util_PoisonMons(u8 taskId);
+static void DebugAction_Util_CheckSaveBlock(u8 taskId);
+static void DebugAction_Util_Weather(u8 taskId);
+static void DebugAction_Util_Weather_SelectId(u8 taskId);
+static void DebugAction_Util_CheckWallClock(u8 taskId);
+static void DebugAction_Util_SetWallClock(u8 taskId);
+static void DebugAction_Util_WatchCredits(u8 taskId);
+static void DebugAction_Util_Trainer_Name(u8 taskId);
+static void DebugAction_Util_Trainer_Gender(u8 taskId);
+static void DebugAction_Util_Trainer_Id(u8 taskId);
+static void DebugAction_Util_CheatStart(u8 taskId);
+
+static void DebugAction_FlagsVars_Flags(u8 taskId);
+static void DebugAction_FlagsVars_FlagsSelect(u8 taskId);
+static void DebugAction_FlagsVars_Vars(u8 taskId);
+static void DebugAction_FlagsVars_Select(u8 taskId);
+static void DebugAction_FlagsVars_SetValue(u8 taskId);
+static void DebugAction_FlagsVars_PokedexFlags_All(u8 taskId);
+static void DebugAction_FlagsVars_PokedexFlags_Reset(u8 taskId);
+static void DebugAction_FlagsVars_SwitchDex(u8 taskId);
+static void DebugAction_FlagsVars_SwitchNatDex(u8 taskId);
+static void DebugAction_FlagsVars_SwitchPokeNav(u8 taskId);
+static void DebugAction_FlagsVars_ToggleFlyFlags(u8 taskId);
+static void DebugAction_FlagsVars_ToggleBadgeFlags(u8 taskId);
+static void DebugAction_FlagsVars_ToggleFrontierPass(u8 taskId);
+static void DebugAction_FlagsVars_BattleDmgOnOff(u8 taskId);
+static void DebugAction_FlagsVars_CollisionOnOff(u8 taskId);
+static void DebugAction_FlagsVars_EncounterOnOff(u8 taskId);
+static void DebugAction_FlagsVars_TrainerSeeOnOff(u8 taskId);
+static void DebugAction_FlagsVars_BagUseOnOff(u8 taskId);
+static void DebugAction_FlagsVars_CatchingOnOff(u8 taskId);
+
+static void Debug_InitializeBattle(u8 taskId);
+
+static void DebugAction_Give_Item(u8 taskId);
+static void DebugAction_Give_Item_SelectId(u8 taskId);
+static void DebugAction_Give_Item_SelectQuantity(u8 taskId);
+static void DebugAction_Give_AllTMs(u8 taskId);
+static void DebugAction_Give_PokemonSimple(u8 taskId);
+static void DebugAction_Give_PokemonComplex(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectId(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectLevel(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectShiny(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectNature(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectAbility(u8 taskId);
+static void DebugAction_Give_Pokemon_SelectIVs(u8 taskId);
+static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId);
+static void DebugAction_Give_Pokemon_Move(u8 taskId);
+static void DebugAction_Give_MaxMoney(u8 taskId);
+static void DebugAction_Give_MaxCoins(u8 taskId);
+static void DebugAction_Give_MaxBattlePoints(u8 taskId);
+static void DebugAction_Give_DayCareEgg(u8 taskId);
+
+static void DebugAction_PkmCreator_Party_Add(u8 taskid);
+static void DebugAction_PkmCreator_Party_Edit(u8 taskid);
+static void DebugAction_PkmCreator_PC_Edit(u8 taskid);
+static void DebugAction_PkmCreator_Enemy_Party_Edit(u8 taskId);
+static void DebugAction_PkmCreator_Enemy_Party_Edit_Debug(u8 taskId);
+static void DebugAction_PkmCreator_Debug_Edit(u8 taskid);
+static void DebugAction_PkmCreator_Enemy_Party_Add(u8 taskid);
+static void DebugAction_PkmCreator_Testing(u8 taskid);
+static void DebugAction_PkmCreator_Testing_Copy(u8 taskid); 
+
+static void DebugAction_Fill_PCBoxes_Fast(u8 taskId);
+static void DebugAction_Fill_PCBoxes_Slow(u8 taskId);
+static void DebugAction_Fill_PCItemStorage(u8 taskId);
+static void DebugAction_Fill_PocketItems(u8 taskId);
+static void DebugAction_Fill_PocketPokeBalls(u8 taskId);
+static void DebugAction_Fill_PocketTMHM(u8 taskId);
+static void DebugAction_Fill_PocketBerries(u8 taskId);
+static void DebugAction_Fill_PocketKeyItems(u8 taskId);
+
+static void DebugAction_Sound_SE(u8 taskId);
+static void DebugAction_Sound_SE_SelectId(u8 taskId);
+static void DebugAction_Sound_MUS(u8 taskId);
+static void DebugAction_Sound_MUS_SelectId(u8 taskId);
+
+extern u8 Debug_Script_1[];
+extern u8 Debug_Script_2[];
+extern u8 Debug_Script_3[];
+extern u8 Debug_Script_4[];
+extern u8 Debug_Script_5[];
+extern u8 Debug_Script_6[];
+extern u8 Debug_Script_7[];
+extern u8 Debug_Script_8[];
+
+extern u8 Debug_ShowFieldMessageStringVar4[];
+extern u8 Debug_CheatStart[];
+extern u8 PlayersHouse_2F_EventScript_SetWallClock[];
+extern u8 PlayersHouse_2F_EventScript_CheckWallClock[];
+#ifdef BATTLE_ENGINE
+#define ABILITY_NAME_LENGTH 16
+#else
+#define ABILITY_NAME_LENGTH 12
+#endif
+extern const u8 gAbilityNames[][ABILITY_NAME_LENGTH + 1];
+
+
+// *******************************
+//Maps per map group COPY FROM /include/constants/map_groups.h
+static const u8 MAP_GROUP_COUNT[] = {57, 5, 5, 6, 7, 8, 9, 7, 7, 14, 8, 17, 10, 23, 13, 15, 15, 2, 2, 2, 3, 1, 1, 1, 108, 61, 89, 2, 1, 13, 1, 1, 3, 1, 0};
+
+// Text
+// General
+static const u8 sDebugText_True[] =          _("TRUE");
+static const u8 sDebugText_False[] =         _("FALSE");
+static const u8 sDebugText_Colored_True[] =  _("{COLOR GREEN}TRUE");
+static const u8 sDebugText_Colored_False[] = _("{COLOR RED}FALSE");
+static const u8 sDebugText_Dashes[] =        _("---");
+static const u8 sDebugText_Empty[] =         _("");
+static const u8 sDebugText_Continue[] =      _("Continue…{CLEAR_TO 110}{RIGHT_ARROW}");
+// Main Menu
+static const u8 sDebugText_Utilities[] =        _("Utilities…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Scripts[] =          _("Scripts…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_FlagsVars[] =        _("Flags & Vars…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle[] =           _("Battle Test…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Give[] =             _("Give X…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_PkmCreator[] =       _("Pokémon Creator…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Fill[] =             _("Fill PC/Pockets…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Sound[] =            _("Sound…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_AccessPC[] =         _("Access PC…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Cancel[] =           _("Cancel");
+// Script menu
+static const u8 sDebugText_Util_Script_1[] =               _("Script 1");
+static const u8 sDebugText_Util_Script_2[] =               _("Script 2");
+static const u8 sDebugText_Util_Script_3[] =               _("Script 3");
+static const u8 sDebugText_Util_Script_4[] =               _("Script 4");
+static const u8 sDebugText_Util_Script_5[] =               _("Script 5");
+static const u8 sDebugText_Util_Script_6[] =               _("Script 6");
+static const u8 sDebugText_Util_Script_7[] =               _("Script 7");
+static const u8 sDebugText_Util_Script_8[] =               _("Script 8");
+// Util Menu
+static const u8 sDebugText_Util_HealParty[] =               _("Heal Party");
+static const u8 sDebugText_Util_Fly[] =                     _("Fly to map…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_WarpToMap[] =               _("Warp to map warp…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_WarpToMap_SelectMapGroup[] =_("Group: {STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n\n{STR_VAR_3}{CLEAR_TO 90}");
+static const u8 sDebugText_Util_WarpToMap_SelectMap[] =     _("Map: {STR_VAR_1}{CLEAR_TO 90}\nMapSec:{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}\n{STR_VAR_3}{CLEAR_TO 90}");
+static const u8 sDebugText_Util_WarpToMap_SelectWarp[] =    _("Warp:{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_3}{CLEAR_TO 90}");
+static const u8 sDebugText_Util_WarpToMap_SelMax[] =        _("{STR_VAR_1} / {STR_VAR_2}");
+static const u8 sDebugText_Util_PoisonMons[] =              _("Poison all mons");
+static const u8 sDebugText_Util_SaveBlockSpace[] =          _("SaveBlock Space…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_Weather[] =                 _("Set weather…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_Weather_ID[] =              _("Weather Id: {STR_VAR_3}\n{STR_VAR_1}\n{STR_VAR_2}");
+static const u8 sDebugText_Util_CheckWallClock[] =          _("Check Wall Clock…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_SetWallClock[] =            _("Set Wall Clock…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_WatchCredits[] =            _("Watch Credits…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Util_Trainer_Name[] =            _("Trainer name");
+static const u8 sDebugText_Util_Trainer_Gender[] =          _("Toggle T. Gender");
+static const u8 sDebugText_Util_Trainer_Id[] =              _("New Trainer Id");
+static const u8 sDebugText_Util_CheatStart[] =              _("CHEAT Start");
+// Flags/Vars Menu
+static const u8 sDebugText_FlagsVars_Flags[] =                  _("Set Flag XYZ…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_FlagsVars_Flag[] =                   _("Flag: {STR_VAR_1}{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}\n{STR_VAR_3}");
+static const u8 sDebugText_FlagsVars_FlagHex[] =                _("{STR_VAR_1}{CLEAR_TO 90}\n0x{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_FlagsVars_Vars[] =                   _("Set Var XYZ…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_FlagsVars_VariableHex[] =            _("{STR_VAR_1}{CLEAR_TO 90}\n0x{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_FlagsVars_Variable[] =               _("Var: {STR_VAR_1}{CLEAR_TO 90}\nVal: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_2}");
+static const u8 sDebugText_FlagsVars_VariableValueSet[] =       _("Var: {STR_VAR_1}{CLEAR_TO 90}\nVal: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_2}");
+static const u8 sDebugText_FlagsVars_PokedexFlags_All[] =       _("Pokédex Flags All");
+static const u8 sDebugText_FlagsVars_PokedexFlags_Reset[] =     _("Pokédex Flags Reset");
+static const u8 sDebugText_FlagsVars_SwitchDex[] =              _("Toggle {STR_VAR_1}Pokédex");
+static const u8 sDebugText_FlagsVars_SwitchNationalDex[] =      _("Toggle {STR_VAR_1}NatDex");
+static const u8 sDebugText_FlagsVars_SwitchPokeNav[] =          _("Toggle {STR_VAR_1}PokéNav");
+static const u8 sDebugText_FlagsVars_RunningShoes[] =           _("Toggle {STR_VAR_1}Running Shoes");
+static const u8 sDebugText_FlagsVars_ToggleFlyFlags[] =         _("Toggle {STR_VAR_1}Fly Flags");
+static const u8 sDebugText_FlagsVars_ToggleAllBadges[] =        _("Toggle {STR_VAR_1}All badges");
+static const u8 sDebugText_FlagsVars_ToggleFrontierPass[] =     _("Toggle {STR_VAR_1}Frontier Pass");
+static const u8 sDebugText_FlagsVars_BattleDmg[] =              _("Toggle {STR_VAR_1}BattleDmg OFF");
+static const u8 sDebugText_FlagsVars_SwitchCollision[] =        _("Toggle {STR_VAR_1}Collision OFF");
+static const u8 sDebugText_FlagsVars_SwitchEncounter[] =        _("Toggle {STR_VAR_1}Encounter OFF");
+static const u8 sDebugText_FlagsVars_SwitchTrainerSee[] =       _("Toggle {STR_VAR_1}TrainerSee OFF");
+static const u8 sDebugText_FlagsVars_SwitchBagUse[] =           _("Toggle {STR_VAR_1}BagUse OFF");
+static const u8 sDebugText_FlagsVars_SwitchCatching[] =         _("Toggle {STR_VAR_1}Catching OFF");
+// Battle
+static const u8 sDebugText_Battle_0_Wild[] =        _("Wild…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_0_WildDouble[] =  _("Wild Double…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_0_Single[] =      _("Single…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_0_Double[] =      _("Double…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_0_Mulit[] =       _("Multi…{CLEAR_TO 110}{RIGHT_ARROW}");
+#ifndef BATTLE_ENGINE
+static const u8 sDebugText_Battle_1_AIFlag_00[] =   _("{STR_VAR_1}Check bad move");
+static const u8 sDebugText_Battle_1_AIFlag_01[] =   _("{STR_VAR_1}Try to faint");
+static const u8 sDebugText_Battle_1_AIFlag_02[] =   _("{STR_VAR_1}Check viability");
+static const u8 sDebugText_Battle_1_AIFlag_03[] =   _("{STR_VAR_1}Setup first turn");
+static const u8 sDebugText_Battle_1_AIFlag_04[] =   _("{STR_VAR_1}Risky");
+static const u8 sDebugText_Battle_1_AIFlag_05[] =   _("{STR_VAR_1}Prefer power extremes");
+static const u8 sDebugText_Battle_1_AIFlag_06[] =   _("{STR_VAR_1}Prefer baton pass");
+static const u8 sDebugText_Battle_1_AIFlag_07[] =   _("{STR_VAR_1}Double battle");
+static const u8 sDebugText_Battle_1_AIFlag_08[] =   _("{STR_VAR_1}Hp aware");
+static const u8 sDebugText_Battle_1_AIFlag_09[] =   _("{STR_VAR_1}Try sunny day start");
+#else
+static const u8 sDebugText_Battle_1_AIFlag_00[] =   _("{STR_VAR_1}Check bad move");
+static const u8 sDebugText_Battle_1_AIFlag_01[] =   _("{STR_VAR_1}Try to faint");
+static const u8 sDebugText_Battle_1_AIFlag_02[] =   _("{STR_VAR_1}Check viability");
+static const u8 sDebugText_Battle_1_AIFlag_03[] =   _("{STR_VAR_1}Setup first turn");
+static const u8 sDebugText_Battle_1_AIFlag_04[] =   _("{STR_VAR_1}Risky");
+static const u8 sDebugText_Battle_1_AIFlag_05[] =   _("{STR_VAR_1}Prefer strongest move");
+static const u8 sDebugText_Battle_1_AIFlag_06[] =   _("{STR_VAR_1}Prefer baton pass");
+static const u8 sDebugText_Battle_1_AIFlag_07[] =   _("{STR_VAR_1}Double battle");
+static const u8 sDebugText_Battle_1_AIFlag_08[] =   _("{STR_VAR_1}Hp aware");
+static const u8 sDebugText_Battle_1_AIFlag_09[] =   _("{STR_VAR_1}Negate unaware");
+static const u8 sDebugText_Battle_1_AIFlag_10[] =   _("{STR_VAR_1}Will suicide");
+static const u8 sDebugText_Battle_1_AIFlag_11[] =   _("{STR_VAR_1}Help partner");
+static const u8 sDebugText_Battle_1_AIFlag_12[] =   _("{STR_VAR_1}Prefer status moves");
+static const u8 sDebugText_Battle_1_AIFlag_13[] =   _("{STR_VAR_1}Stall");
+static const u8 sDebugText_Battle_1_AIFlag_14[] =   _("{STR_VAR_1}Screener");
+static const u8 sDebugText_Battle_1_AIFlag_15[] =   _("{STR_VAR_1}Smart switching");
+static const u8 sDebugText_Battle_1_AIFlag_16[] =   _("{STR_VAR_1}Ace pokemon");
+#endif
+static const u8 sDebugText_Battle_2_Terrain_0[] =   _("Grass…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_1[] =   _("Long grass…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_2[] =   _("Sand…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_3[] =   _("Underwater…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_4[] =   _("Water…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_5[] =   _("Pond…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_6[] =   _("Mountain…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_7[] =   _("Cave…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_8[] =   _("Building…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Battle_2_Terrain_9[] =   _("Plain…{CLEAR_TO 110}{RIGHT_ARROW}");
+// Give Menu
+static const u8 sDebugText_Give_GiveItem[] =            _("Give item XYZ…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_ItemQuantity[] =             _("Quantity:{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n\n{STR_VAR_2}");
+static const u8 sDebugText_ItemID[] =                   _("Item Id: {STR_VAR_3}\n{STR_VAR_1}{CLEAR_TO 90}\n\n{STR_VAR_2}");
+static const u8 sDebugText_Give_AllTMs[] =              _("Give all TMs");
+static const u8 sDebugText_Give_GivePokemonSimple[] =   _("Pkm (lvl)…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Give_GivePokemonComplex[] =  _("Pkm (l,s,n,a,IV,mov)…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_PokemonID[] =                _("Species: {STR_VAR_3}\n{STR_VAR_1}{CLEAR_TO 90}\n\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonLevel[] =             _("Level:{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonShiny[] =             _("Shiny:{CLEAR_TO 90}\n   {STR_VAR_2}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonNature[] =            _("NatureId: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonAbility[] =           _("AbilityNum: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIVs[] =               _("All IVs:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_0[] =              _("IV HP:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_1[] =              _("IV Attack:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_2[] =              _("IV Defense:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_3[] =              _("IV Speed:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_4[] =              _("IV Sp. Attack:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonIV_5[] =              _("IV Sp. Defense:{CLEAR_TO 90}\n    {STR_VAR_3}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonMove_0[] =            _("Move 0: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonMove_1[] =            _("Move 1: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonMove_2[] =            _("Move 2: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_PokemonMove_3[] =            _("Move 3: {STR_VAR_3}{CLEAR_TO 90}\n{STR_VAR_1}{CLEAR_TO 90}\n{CLEAR_TO 90}\n{STR_VAR_2}{CLEAR_TO 90}");
+static const u8 sDebugText_Give_MaxMoney[] =            _("Max Money");
+static const u8 sDebugText_Give_MaxCoins[] =            _("Max Coins");
+static const u8 sDebugText_Give_BattlePoints[] =        _("Max Battle Points");
+static const u8 sDebugText_Give_DaycareEgg[] =          _("Daycare Egg");
+// Pokemon Creator
+static const u8 sDebugText_PkmCreator_Party_Add[] =                 _("Party add");
+static const u8 sDebugText_PkmCreator_Party_Edit[] =                _("Party edit");
+static const u8 sDebugText_PkmCreator_PC_Edit[] =                   _("PC edit");
+static const u8 sDebugText_PkmCreator_Enemy_Party_Edit[] =          _("Enemy edit");
+static const u8 sDebugText_PkmCreator_Enemy_Party_Edit_Debug[] =    _("Enemy edit debug");
+static const u8 sDebugText_PkmCreator_Debug_Edit[] =                _("Debug edit");
+static const u8 sDebugText_PkmCreator_Enemy_Party_Add[] =           _("Enemy add");
+static const u8 sDebugText_PkmCreator_Testing[] =                   _("Testing");
+static const u8 sDebugText_PkmCreator_Testing_Copy[] =              _("Testing (copy 1st mon)");
+// Fill Menu
+static const u8 sDebugText_Fill_Pc_Fast[] =        _("Fill PCBoxes Fast");
+static const u8 sDebugText_Fill_Pc_Slow[] =        _("Fill PCBoxes Slow (LAG!)");
+static const u8 sDebugText_Fill_Pc_Items[] =       _("Fill PCItems");
+static const u8 sDebugText_Fill_PocketItems[] =    _("Fill Pocket Items");
+static const u8 sDebugText_Fill_PocketPokeBalls[] =_("Fill Pocket PokeBalls");
+static const u8 sDebugText_Fill_PocketTMHM[] =     _("Fill Pocket TMHM");
+static const u8 sDebugText_Fill_PocketBerries[] =  _("Fill Pocket Berries");
+static const u8 sDebugText_Fill_PocketKeyItems[] = _("Fill Pocket KeyItems");
+// Sound Mneu
+static const u8 sDebugText_Sound_SE[] =                 _("Effects…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Sound_SE_ID[] =              _("Sound Id: {STR_VAR_3}\n{STR_VAR_1}    \n{STR_VAR_2}");
+static const u8 sDebugText_Sound_MUS[] =                _("Music…{CLEAR_TO 110}{RIGHT_ARROW}");
+static const u8 sDebugText_Sound_MUS_ID[] =             _("Music Id: {STR_VAR_3}\n{STR_VAR_1}    \n{STR_VAR_2}");
+
+static const u8 digitInidicator_1[] =               _("{LEFT_ARROW}+1{RIGHT_ARROW}        ");
+static const u8 digitInidicator_10[] =              _("{LEFT_ARROW}+10{RIGHT_ARROW}       ");
+static const u8 digitInidicator_100[] =             _("{LEFT_ARROW}+100{RIGHT_ARROW}      ");
+static const u8 digitInidicator_1000[] =            _("{LEFT_ARROW}+1000{RIGHT_ARROW}     ");
+static const u8 digitInidicator_10000[] =           _("{LEFT_ARROW}+10000{RIGHT_ARROW}    ");
+static const u8 digitInidicator_100000[] =          _("{LEFT_ARROW}+100000{RIGHT_ARROW}   ");
+static const u8 digitInidicator_1000000[] =         _("{LEFT_ARROW}+1000000{RIGHT_ARROW}  ");
+static const u8 digitInidicator_10000000[] =        _("{LEFT_ARROW}+10000000{RIGHT_ARROW} ");
+const u8 * const gText_DigitIndicator[] =
+{
+    digitInidicator_1,
+    digitInidicator_10,
+    digitInidicator_100,
+    digitInidicator_1000,
+    digitInidicator_10000,
+    digitInidicator_100000,
+    digitInidicator_1000000,
+    digitInidicator_10000000
+};
+static const s32 sPowersOfTen[] =
+{
+             1,
+            10,
+           100,
+          1000,
+         10000,
+        100000,
+       1000000,
+      10000000,
+     100000000,
+    1000000000,
+};
+
+// *******************************
+// List Menu Items
+static const struct ListMenuItem sDebugMenu_Items_Main[] =
+{
+    [DEBUG_MENU_ITEM_UTILITIES]       = {sDebugText_Utilities,  DEBUG_MENU_ITEM_UTILITIES},
+    [DEBUG_MENU_ITEM_SCRIPTS]         = {sDebugText_Scripts,    DEBUG_MENU_ITEM_SCRIPTS},
+    [DEBUG_MENU_ITEM_FLAGVAR]         = {sDebugText_FlagsVars,  DEBUG_MENU_ITEM_FLAGVAR},
+    [DEBUG_MENU_ITEM_BATTLE]          = {sDebugText_Battle,     DEBUG_MENU_ITEM_BATTLE},
+    [DEBUG_MENU_ITEM_GIVE]            = {sDebugText_Give,       DEBUG_MENU_ITEM_GIVE},
+    [DEBUG_MENU_ITEM_POKEMON_CREATOR] = {sDebugText_PkmCreator, DEBUG_MENU_ITEM_POKEMON_CREATOR},
+    [DEBUG_MENU_ITEM_FILL]            = {sDebugText_Fill,       DEBUG_MENU_ITEM_FILL},
+    [DEBUG_MENU_ITEM_SOUND]           = {sDebugText_Sound,      DEBUG_MENU_ITEM_SOUND},
+    [DEBUG_MENU_ITEM_ACCESS_PC]       = {sDebugText_AccessPC,   DEBUG_MENU_ITEM_ACCESS_PC},
+    [DEBUG_MENU_ITEM_CANCEL]          = {sDebugText_Cancel,     DEBUG_MENU_ITEM_CANCEL}
+};
+static const struct ListMenuItem sDebugMenu_Items_Utilities[] =
+{
+    [DEBUG_UTIL_MENU_ITEM_HEAL_PARTY]       = {sDebugText_Util_HealParty,        DEBUG_UTIL_MENU_ITEM_HEAL_PARTY},
+    [DEBUG_UTIL_MENU_ITEM_FLY]              = {sDebugText_Util_Fly,              DEBUG_UTIL_MENU_ITEM_FLY},
+    [DEBUG_UTIL_MENU_ITEM_WARP]             = {sDebugText_Util_WarpToMap,        DEBUG_UTIL_MENU_ITEM_WARP},
+    [DEBUG_UTIL_MENU_ITEM_POISON_MONS]      = {sDebugText_Util_PoisonMons,       DEBUG_UTIL_MENU_ITEM_POISON_MONS},
+    [DEBUG_UTIL_MENU_ITEM_SAVEBLOCK]        = {sDebugText_Util_SaveBlockSpace,   DEBUG_UTIL_MENU_ITEM_SAVEBLOCK},
+    [DEBUG_UTIL_MENU_ITEM_WEATHER]          = {sDebugText_Util_Weather,          DEBUG_UTIL_MENU_ITEM_WEATHER},
+    [DEBUG_UTIL_MENU_ITEM_CHECKWALLCLOCK]   = {sDebugText_Util_CheckWallClock,   DEBUG_UTIL_MENU_ITEM_CHECKWALLCLOCK},
+    [DEBUG_UTIL_MENU_ITEM_SETWALLCLOCK]     = {sDebugText_Util_SetWallClock,     DEBUG_UTIL_MENU_ITEM_SETWALLCLOCK},
+    [DEBUG_UTIL_MENU_ITEM_WATCHCREDITS]     = {sDebugText_Util_WatchCredits,     DEBUG_UTIL_MENU_ITEM_WATCHCREDITS},
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_NAME]     = {sDebugText_Util_Trainer_Name,     DEBUG_UTIL_MENU_ITEM_TRAINER_NAME},
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_GENDER]   = {sDebugText_Util_Trainer_Gender,   DEBUG_UTIL_MENU_ITEM_TRAINER_GENDER},
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_ID]       = {sDebugText_Util_Trainer_Id,       DEBUG_UTIL_MENU_ITEM_TRAINER_ID},
+    [DEBUG_UTIL_MENU_ITEM_CHEAT]            = {sDebugText_Util_CheatStart,        DEBUG_UTIL_MENU_ITEM_CHEAT},
+};
+static const struct ListMenuItem sDebugMenu_Items_Scripts[] =
+{
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_1]     = {sDebugText_Util_Script_1,    DEBUG_UTIL_MENU_ITEM_SCRIPT_1},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_2]     = {sDebugText_Util_Script_2,    DEBUG_UTIL_MENU_ITEM_SCRIPT_2},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_3]     = {sDebugText_Util_Script_3,    DEBUG_UTIL_MENU_ITEM_SCRIPT_3},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_4]     = {sDebugText_Util_Script_4,    DEBUG_UTIL_MENU_ITEM_SCRIPT_4},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_5]     = {sDebugText_Util_Script_5,    DEBUG_UTIL_MENU_ITEM_SCRIPT_5},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_6]     = {sDebugText_Util_Script_6,    DEBUG_UTIL_MENU_ITEM_SCRIPT_6},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_7]     = {sDebugText_Util_Script_7,    DEBUG_UTIL_MENU_ITEM_SCRIPT_7},
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_8]     = {sDebugText_Util_Script_8,    DEBUG_UTIL_MENU_ITEM_SCRIPT_8},
+};
+static const struct ListMenuItem sDebugMenu_Items_FlagsVars[] =
+{
+    [DEBUG_FLAGVAR_MENU_ITEM_FLAGS]                = {sDebugText_FlagsVars_Flags,              DEBUG_FLAGVAR_MENU_ITEM_FLAGS},
+    [DEBUG_FLAGVAR_MENU_ITEM_VARS]                 = {sDebugText_FlagsVars_Vars,               DEBUG_FLAGVAR_MENU_ITEM_VARS},
+    [DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_ALL]         = {sDebugText_FlagsVars_PokedexFlags_All,   DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_ALL},
+    [DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_RESET]       = {sDebugText_FlagsVars_PokedexFlags_Reset, DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_RESET},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKEDEX]       = {sDebugText_FlagsVars_SwitchDex,          DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKEDEX},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_NATDEX]        = {sDebugText_FlagsVars_SwitchNationalDex,  DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_NATDEX},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKENAV]       = {sDebugText_FlagsVars_SwitchPokeNav,      DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKENAV},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_RUN_SHOES]     = {sDebugText_FlagsVars_RunningShoes,       DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_RUN_SHOES},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_LOCATIONS]     = {sDebugText_FlagsVars_ToggleFlyFlags,     DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_LOCATIONS},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BADGES_ALL]    = {sDebugText_FlagsVars_ToggleAllBadges,    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BADGES_ALL},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_FRONTIER_PASS] = {sDebugText_FlagsVars_ToggleFrontierPass, DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_FRONTIER_PASS},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BATTLE_DMG]    = {sDebugText_FlagsVars_BattleDmg,          DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BATTLE_DMG},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_COLISSION]     = {sDebugText_FlagsVars_SwitchCollision,    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_COLISSION},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_ENCOUNTER]     = {sDebugText_FlagsVars_SwitchEncounter,    DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_ENCOUNTER},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_TRAINER_SEE]   = {sDebugText_FlagsVars_SwitchTrainerSee,   DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_TRAINER_SEE},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BAG_USE]       = {sDebugText_FlagsVars_SwitchBagUse,       DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BAG_USE},
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_CATCHING]      = {sDebugText_FlagsVars_SwitchCatching,     DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_CATCHING},
+};
+static const struct ListMenuItem sDebugMenu_Items_Battle_0[] =
+{
+    [DEBUG_BATTLE_0_MENU_ITEM_WILD]        = {sDebugText_Battle_0_Wild,       DEBUG_BATTLE_0_MENU_ITEM_WILD},
+    #ifdef BATTLE_ENGINE
+    [DEBUG_BATTLE_0_MENU_ITEM_WILD_DOUBLE] = {sDebugText_Battle_0_WildDouble, DEBUG_BATTLE_0_MENU_ITEM_WILD_DOUBLE},
+    #endif
+    [DEBUG_BATTLE_0_MENU_ITEM_SINGLE]      = {sDebugText_Battle_0_Single,     DEBUG_BATTLE_0_MENU_ITEM_SINGLE},
+    [DEBUG_BATTLE_0_MENU_ITEM_DOUBLE]      = {sDebugText_Battle_0_Double,     DEBUG_BATTLE_0_MENU_ITEM_DOUBLE},
+    [DEBUG_BATTLE_0_MENU_ITEM_MULTI]       = {sDebugText_Battle_0_Mulit,      DEBUG_BATTLE_0_MENU_ITEM_MULTI},
+};
+static const struct ListMenuItem sDebugMenu_Items_Battle_1[] =
+{
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_00] = {sDebugText_Battle_1_AIFlag_00, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_00},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_01] = {sDebugText_Battle_1_AIFlag_01, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_01},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_02] = {sDebugText_Battle_1_AIFlag_02, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_02},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_03] = {sDebugText_Battle_1_AIFlag_03, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_03},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_04] = {sDebugText_Battle_1_AIFlag_04, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_04},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_05] = {sDebugText_Battle_1_AIFlag_05, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_05},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_06] = {sDebugText_Battle_1_AIFlag_06, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_06},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_07] = {sDebugText_Battle_1_AIFlag_07, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_07},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_08] = {sDebugText_Battle_1_AIFlag_08, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_08},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_09] = {sDebugText_Battle_1_AIFlag_09, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_09},
+#ifdef BATTLE_ENGINE
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_10] = {sDebugText_Battle_1_AIFlag_10, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_10},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_11] = {sDebugText_Battle_1_AIFlag_11, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_11},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_12] = {sDebugText_Battle_1_AIFlag_12, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_12},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_13] = {sDebugText_Battle_1_AIFlag_13, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_13},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_14] = {sDebugText_Battle_1_AIFlag_14, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_14},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_15] = {sDebugText_Battle_1_AIFlag_15, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_15},
+    [DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_16] = {sDebugText_Battle_1_AIFlag_16, DEBUG_BATTLE_1_MENU_ITEM_AI_FLAG_16},
+#endif
+    [DEBUG_BATTLE_1_MENU_ITEM_CONTINUE]   = {sDebugText_Continue,           DEBUG_BATTLE_1_MENU_ITEM_CONTINUE},
+};
+static const struct ListMenuItem sDebugMenu_Items_Battle_2[] =
+{
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_0]     = {sDebugText_Battle_2_Terrain_0,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_0},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_1]     = {sDebugText_Battle_2_Terrain_1,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_1},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_2]     = {sDebugText_Battle_2_Terrain_2,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_2},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_3]     = {sDebugText_Battle_2_Terrain_3,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_3},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_4]     = {sDebugText_Battle_2_Terrain_4,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_4},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_5]     = {sDebugText_Battle_2_Terrain_5,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_5},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_6]     = {sDebugText_Battle_2_Terrain_6,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_6},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_7]     = {sDebugText_Battle_2_Terrain_7,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_7},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_8]     = {sDebugText_Battle_2_Terrain_8,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_8},
+    [DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_9]     = {sDebugText_Battle_2_Terrain_9,    DEBUG_BATTLE_2_MENU_ITEM_TERRAIN_9},
+};
+static const struct ListMenuItem sDebugMenu_Items_Give[] =
+{
+    [DEBUG_GIVE_MENU_ITEM_ITEM_X]            = {sDebugText_Give_GiveItem,           DEBUG_GIVE_MENU_ITEM_ITEM_X},
+    [DEBUG_GIVE_MENU_ITEM_ALLTMS]            = {sDebugText_Give_AllTMs,             DEBUG_GIVE_MENU_ITEM_ALLTMS},
+    [DEBUG_GIVE_MENU_ITEM_POKEMON_SIMPLE]    = {sDebugText_Give_GivePokemonSimple,  DEBUG_GIVE_MENU_ITEM_POKEMON_SIMPLE},
+    [DEBUG_GIVE_MENU_ITEM_POKEMON_COMPLEX]   = {sDebugText_Give_GivePokemonComplex, DEBUG_GIVE_MENU_ITEM_POKEMON_COMPLEX},
+    [DEBUG_GIVE_MENU_ITEM_MAX_MONEY]         = {sDebugText_Give_MaxMoney,           DEBUG_GIVE_MENU_ITEM_MAX_MONEY},
+    [DEBUG_GIVE_MENU_ITEM_MAX_COINS]         = {sDebugText_Give_MaxCoins,           DEBUG_GIVE_MENU_ITEM_MAX_COINS},
+    [DEBUG_GIVE_MENU_ITEM_MAX_BATTLE_POINTS] = {sDebugText_Give_BattlePoints,       DEBUG_GIVE_MENU_ITEM_MAX_BATTLE_POINTS},
+    [DEBUG_GIVE_MENU_ITEM_DAYCARE_EGG]       = {sDebugText_Give_DaycareEgg,         DEBUG_GIVE_MENU_ITEM_DAYCARE_EGG},
+};
+static const struct ListMenuItem sDebugMenu_Items_PkmCreator[] =
+{
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_ADD]              =  {sDebugText_PkmCreator_Party_Add,              DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_ADD},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_EDIT]             =  {sDebugText_PkmCreator_Party_Edit,             DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_EDIT},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PC_EDIT]                =  {sDebugText_PkmCreator_PC_Edit,                DEBUG_PKM_CREATOR_MENU_ITEM_PC_EDIT},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT]       =  {sDebugText_PkmCreator_Enemy_Party_Edit,       DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT_DEBUG] =  {sDebugText_PkmCreator_Enemy_Party_Edit_Debug, DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT_DEBUG},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_DEBUG_EDIT]             =  {sDebugText_PkmCreator_Debug_Edit,             DEBUG_PKM_CREATOR_MENU_ITEM_DEBUG_EDIT},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_ADD]        =  {sDebugText_PkmCreator_Enemy_Party_Add,        DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_ADD},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_TESTING]                =  {sDebugText_PkmCreator_Testing,                DEBUG_PKM_CREATOR_MENU_ITEM_TESTING},
+    [DEBUG_PKM_CREATOR_MENU_ITEM_TESTING_COPY]           =  {sDebugText_PkmCreator_Testing_Copy,           DEBUG_PKM_CREATOR_MENU_ITEM_TESTING_COPY},
+};
+static const struct ListMenuItem sDebugMenu_Items_Fill[] =
+{
+    [DEBUG_FILL_MENU_ITEM_PC_BOXES_FAST]    = {sDebugText_Fill_Pc_Fast,         DEBUG_FILL_MENU_ITEM_PC_BOXES_FAST},
+    [DEBUG_FILL_MENU_ITEM_PC_BOXES_SLOW]    = {sDebugText_Fill_Pc_Slow,         DEBUG_FILL_MENU_ITEM_PC_BOXES_SLOW},
+    [DEBUG_FILL_MENU_ITEM_PC_ITEMS]         = {sDebugText_Fill_Pc_Items ,       DEBUG_FILL_MENU_ITEM_PC_ITEMS},
+    [DEBUG_FILL_MENU_ITEM_POCKET_ITEMS]     = {sDebugText_Fill_PocketItems,     DEBUG_FILL_MENU_ITEM_POCKET_ITEMS},
+    [DEBUG_FILL_MENU_ITEM_POCKET_BALLS]     = {sDebugText_Fill_PocketPokeBalls, DEBUG_FILL_MENU_ITEM_POCKET_BALLS},
+    [DEBUG_FILL_MENU_ITEM_POCKET_TMHM]      = {sDebugText_Fill_PocketTMHM,      DEBUG_FILL_MENU_ITEM_POCKET_TMHM},
+    [DEBUG_FILL_MENU_ITEM_POCKET_BERRIES]   = {sDebugText_Fill_PocketBerries,   DEBUG_FILL_MENU_ITEM_POCKET_BERRIES},
+    [DEBUG_FILL_MENU_ITEM_POCKET_KEY_ITEMS] = {sDebugText_Fill_PocketKeyItems,  DEBUG_FILL_MENU_ITEM_POCKET_KEY_ITEMS},
+};
+static const struct ListMenuItem sDebugMenu_Items_Sound[] =
+{
+    [DEBUG_SOUND_MENU_ITEM_SE]            = {sDebugText_Sound_SE,         DEBUG_SOUND_MENU_ITEM_SE},
+    [DEBUG_SOUND_MENU_ITEM_MUS]           = {sDebugText_Sound_MUS,        DEBUG_SOUND_MENU_ITEM_MUS},
+};
+
+// *******************************
+// Menu Actions
+static void (*const sDebugMenu_Actions_Main[])(u8) =
+{
+    [DEBUG_MENU_ITEM_UTILITIES]       = DebugAction_OpenUtilitiesMenu,
+    [DEBUG_MENU_ITEM_SCRIPTS]         = DebugAction_OpenScriptsMenu,
+    [DEBUG_MENU_ITEM_FLAGVAR]         = DebugAction_OpenFlagsVarsMenu,
+    [DEBUG_MENU_ITEM_BATTLE]          = DebugAction_OpenBattleMenu,
+    [DEBUG_MENU_ITEM_GIVE]            = DebugAction_OpenGiveMenu,
+    [DEBUG_MENU_ITEM_POKEMON_CREATOR] = DebugAction_OpenPokemonCreator,
+    [DEBUG_MENU_ITEM_FILL]            = DebugAction_OpenFillMenu,
+    [DEBUG_MENU_ITEM_SOUND]           = DebugAction_OpenSoundMenu,
+    [DEBUG_MENU_ITEM_ACCESS_PC]       = DebugAction_AccessPC,
+    [DEBUG_MENU_ITEM_CANCEL]          = DebugAction_Cancel
+};
+static void (*const sDebugMenu_Actions_Utilities[])(u8) =
+{
+    [DEBUG_UTIL_MENU_ITEM_HEAL_PARTY]       = DebugAction_Util_HealParty,
+    [DEBUG_UTIL_MENU_ITEM_FLY]              = DebugAction_Util_Fly,
+    [DEBUG_UTIL_MENU_ITEM_WARP]             = DebugAction_Util_Warp_Warp,
+    [DEBUG_UTIL_MENU_ITEM_POISON_MONS]      = DebugAction_Util_PoisonMons,
+    [DEBUG_UTIL_MENU_ITEM_SAVEBLOCK]        = DebugAction_Util_CheckSaveBlock,
+    [DEBUG_UTIL_MENU_ITEM_WEATHER]          = DebugAction_Util_Weather,
+    [DEBUG_UTIL_MENU_ITEM_CHECKWALLCLOCK]   = DebugAction_Util_CheckWallClock,
+    [DEBUG_UTIL_MENU_ITEM_SETWALLCLOCK]     = DebugAction_Util_SetWallClock,
+    [DEBUG_UTIL_MENU_ITEM_WATCHCREDITS]     = DebugAction_Util_WatchCredits,
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_NAME]     = DebugAction_Util_Trainer_Name,
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_GENDER]   = DebugAction_Util_Trainer_Gender,
+    [DEBUG_UTIL_MENU_ITEM_TRAINER_ID]       = DebugAction_Util_Trainer_Id,
+    [DEBUG_UTIL_MENU_ITEM_CHEAT]            = DebugAction_Util_CheatStart,
+};
+static void (*const sDebugMenu_Actions_Scripts[])(u8) =
+{
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_1]     = DebugAction_Util_Script_1,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_2]     = DebugAction_Util_Script_2,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_3]     = DebugAction_Util_Script_3,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_4]     = DebugAction_Util_Script_4,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_5]     = DebugAction_Util_Script_5,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_6]     = DebugAction_Util_Script_6,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_7]     = DebugAction_Util_Script_7,
+    [DEBUG_UTIL_MENU_ITEM_SCRIPT_8]     = DebugAction_Util_Script_8,
+};
+static void (*const sDebugMenu_Actions_Flags[])(u8) =
+{
+    [DEBUG_FLAGVAR_MENU_ITEM_FLAGS]                = DebugAction_FlagsVars_Flags,
+    [DEBUG_FLAGVAR_MENU_ITEM_VARS]                 = DebugAction_FlagsVars_Vars,
+    [DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_ALL]         = DebugAction_FlagsVars_PokedexFlags_All,
+    [DEBUG_FLAGVAR_MENU_ITEM_DEXFLAGS_RESET]       = DebugAction_FlagsVars_PokedexFlags_Reset,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKEDEX]       = DebugAction_FlagsVars_SwitchDex,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_NATDEX]        = DebugAction_FlagsVars_SwitchNatDex,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKENAV]       = DebugAction_FlagsVars_SwitchPokeNav,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_RUN_SHOES]     = DebugAction_FlagsVars_RunningShoes,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_LOCATIONS]     = DebugAction_FlagsVars_ToggleFlyFlags,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BADGES_ALL]    = DebugAction_FlagsVars_ToggleBadgeFlags,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_FRONTIER_PASS] = DebugAction_FlagsVars_ToggleFrontierPass,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BATTLE_DMG]    = DebugAction_FlagsVars_BattleDmgOnOff,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_COLISSION]     = DebugAction_FlagsVars_CollisionOnOff,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_ENCOUNTER]     = DebugAction_FlagsVars_EncounterOnOff,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_TRAINER_SEE]   = DebugAction_FlagsVars_TrainerSeeOnOff,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BAG_USE]       = DebugAction_FlagsVars_BagUseOnOff,
+    [DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_CATCHING]      = DebugAction_FlagsVars_CatchingOnOff,
+};
+static void (*const sDebugMenu_Actions_Give[])(u8) =
+{
+    [DEBUG_GIVE_MENU_ITEM_ITEM_X]            = DebugAction_Give_Item,
+    [DEBUG_GIVE_MENU_ITEM_ALLTMS]            = DebugAction_Give_AllTMs,
+    [DEBUG_GIVE_MENU_ITEM_POKEMON_SIMPLE]    = DebugAction_Give_PokemonSimple,
+    [DEBUG_GIVE_MENU_ITEM_POKEMON_COMPLEX]   = DebugAction_Give_PokemonComplex,
+    [DEBUG_GIVE_MENU_ITEM_MAX_MONEY]         = DebugAction_Give_MaxMoney,
+    [DEBUG_GIVE_MENU_ITEM_MAX_COINS]         = DebugAction_Give_MaxCoins,
+    [DEBUG_GIVE_MENU_ITEM_MAX_BATTLE_POINTS] = DebugAction_Give_MaxBattlePoints,
+    [DEBUG_GIVE_MENU_ITEM_DAYCARE_EGG]       = DebugAction_Give_DayCareEgg,
+};
+static void (*const sDebugMenu_Actions_PkmCreator[])(u8) =
+{
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_ADD]              = DebugAction_PkmCreator_Party_Add,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PARTY_EDIT]             = DebugAction_PkmCreator_Party_Edit,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_PC_EDIT]                = DebugAction_PkmCreator_PC_Edit,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT]       = DebugAction_PkmCreator_Enemy_Party_Edit,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_EDIT_DEBUG] = DebugAction_PkmCreator_Enemy_Party_Edit_Debug,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_DEBUG_EDIT]             = DebugAction_PkmCreator_Debug_Edit,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_ENEMY_PARTY_ADD]        = DebugAction_PkmCreator_Enemy_Party_Add,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_TESTING]                = DebugAction_PkmCreator_Testing,
+    [DEBUG_PKM_CREATOR_MENU_ITEM_TESTING_COPY]           = DebugAction_PkmCreator_Testing_Copy,
+};
+static void (*const sDebugMenu_Actions_Fill[])(u8) =
+{
+    [DEBUG_FILL_MENU_ITEM_PC_BOXES_FAST]    = DebugAction_Fill_PCBoxes_Fast,
+    [DEBUG_FILL_MENU_ITEM_PC_BOXES_SLOW]    = DebugAction_Fill_PCBoxes_Slow,
+    [DEBUG_FILL_MENU_ITEM_PC_ITEMS]         = DebugAction_Fill_PCItemStorage,
+    [DEBUG_FILL_MENU_ITEM_POCKET_ITEMS]     = DebugAction_Fill_PocketItems,
+    [DEBUG_FILL_MENU_ITEM_POCKET_BALLS]     = DebugAction_Fill_PocketPokeBalls,
+    [DEBUG_FILL_MENU_ITEM_POCKET_TMHM]      = DebugAction_Fill_PocketTMHM,
+    [DEBUG_FILL_MENU_ITEM_POCKET_BERRIES]   = DebugAction_Fill_PocketBerries,
+    [DEBUG_FILL_MENU_ITEM_POCKET_KEY_ITEMS] = DebugAction_Fill_PocketKeyItems,
+};
+
+static void (*const sDebugMenu_Actions_Sound[])(u8) =
+{
+    [DEBUG_SOUND_MENU_ITEM_SE]      = DebugAction_Sound_SE,
+    [DEBUG_SOUND_MENU_ITEM_MUS]     = DebugAction_Sound_MUS,
+};
+
+
+// *******************************
+// Windows
+static const struct WindowTemplate sDebugMenuWindowTemplateMain =
+{
+    .bg = 0,
+    .tilemapLeft = 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MENU_WIDTH_MAIN,
+    .height = 2 * DEBUG_MENU_HEIGHT_MAIN,
+    .paletteNum = 15,
+    .baseBlock = 1,
+};
+static const struct WindowTemplate sDebugMenuWindowTemplateExtra =
+{
+    .bg = 0,
+    .tilemapLeft = 30 - DEBUG_MENU_WIDTH_EXTRA - 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MENU_WIDTH_EXTRA,
+    .height = 2 * DEBUG_MENU_HEIGHT_EXTRA,
+    .paletteNum = 15,
+    .baseBlock = 1,
+};
+static const struct WindowTemplate sDebugMenuWindowTemplateWeather =
+{
+    .bg = 0,
+    .tilemapLeft = 30 - DEBUG_MENU_WIDTH_WEATHER - 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MENU_WIDTH_WEATHER,
+    .height = 2 * DEBUG_MENU_HEIGHT_WEATHER,
+    .paletteNum = 15,
+    .baseBlock = 1,
+};
+static const struct WindowTemplate sDebugMenuWindowTemplateSound =
+{
+    .bg = 0,
+    .tilemapLeft = 30 - DEBUG_MENU_WIDTH_SOUND - 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MENU_WIDTH_SOUND,
+    .height = DEBUG_MENU_HEIGHT_SOUND,
+    .paletteNum = 15,
+    .baseBlock = 1,
+};
+static const struct WindowTemplate sDebugMenuWindowTemplateFlagsVars =
+{
+    .bg = 0,
+    .tilemapLeft = 30 - DEBUG_MENU_WIDTH_FLAGVAR - 1,
+    .tilemapTop = 1,
+    .width = DEBUG_MENU_WIDTH_FLAGVAR,
+    .height = DEBUG_MENU_HEIGHT_FLAGVAR,
+    .paletteNum = 15,
+    .baseBlock = 1 + DEBUG_MENU_WIDTH_MAIN * DEBUG_MENU_HEIGHT_MAIN * 2,
+};
+
+// *******************************
+// List Menu Templates
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Main =
+{
+    .items = sDebugMenu_Items_Main,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Main),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Utilities =
+{
+    .items = sDebugMenu_Items_Utilities,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Utilities),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Scripts =
+{
+    .items = sDebugMenu_Items_Scripts,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Scripts),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_FlagsVars =
+{
+    .items = sDebugMenu_Items_FlagsVars,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_FlagsVars),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Battle_0 =
+{
+    .items = sDebugMenu_Items_Battle_0,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Battle_0),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Battle_1 =
+{
+    .items = sDebugMenu_Items_Battle_1,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Battle_1),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Battle_2 =
+{
+    .items = sDebugMenu_Items_Battle_2,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Battle_2),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Give =
+{
+    .items = sDebugMenu_Items_Give,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Give),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_PkmCreator =
+{
+    .items = sDebugMenu_Items_PkmCreator,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_PkmCreator),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Fill =
+{
+    .items = sDebugMenu_Items_Fill,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Fill),
+};
+static const struct ListMenuTemplate sDebugMenu_ListTemplate_Sound =
+{
+    .items = sDebugMenu_Items_Sound,
+    .moveCursorFunc = ListMenuDefaultCursorMoveFunc,
+    .totalItems = ARRAY_COUNT(sDebugMenu_Items_Sound),
+};
+
+
+// *******************************
+// Functions universal
+void Debug_ShowMainMenu(void)
+{
+    sDebugBattleData = AllocZeroed(sizeof(*sDebugBattleData));
+    sDebugMenuListData = AllocZeroed(sizeof(*sDebugMenuListData));
+    Debug_InitDebugBattleData();
+
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Main, sDebugMenu_ListTemplate_Main);
+}
+static void Debug_ReShowMainMenu(void)
+{
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Main, sDebugMenu_ListTemplate_Main);
+}
+static u8 Debug_ShowMenu(void (*HandleInput)(u8), struct ListMenuTemplate LMtemplate)
+{
+    struct ListMenuTemplate menuTemplate;
+    u8 windowId;
+    u8 menuTaskId;
+    u8 inputTaskId;
+
+    // create window
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateMain);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    // create list menu
+    menuTemplate = LMtemplate;
+    menuTemplate.maxShowed = DEBUG_MENU_HEIGHT_MAIN;
+    menuTemplate.windowId = windowId;
+    menuTemplate.header_X = 0;
+    menuTemplate.item_X = 8;
+    menuTemplate.cursor_X = 0;
+    menuTemplate.upText_Y = 1;
+    menuTemplate.cursorPal = 2;
+    menuTemplate.fillValue = 1;
+    menuTemplate.cursorShadowPal = 3;
+    menuTemplate.lettersSpacing = 1;
+    menuTemplate.itemVerticalPadding = 0;
+    menuTemplate.scrollMultiple = LIST_NO_MULTIPLE_SCROLL;
+    menuTemplate.fontId = 1;
+    menuTemplate.cursorKind = 0;
+    menuTaskId = ListMenuInit(&menuTemplate, 0, 0);
+
+    // create input handler task
+    inputTaskId = CreateTask(HandleInput, 3);
+    gTasks[inputTaskId].data[0] = menuTaskId;
+    gTasks[inputTaskId].data[1] = windowId;
+    gTasks[inputTaskId].data[2] = 0;
+
+    Debug_RefreshListMenu(inputTaskId);
+
+    // draw everything
+    CopyWindowToVram(windowId, 3);
+
+    // return taskId for use right after
+    return inputTaskId;
+}
+void Debug_ReShowBattleDebugMenu(void)
+{
+    u8 taskId = Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, gMultiuseListMenuTemplate);
+    Debug_RedrawListMenu(taskId);
+}
+static void Debug_DestroyMenu(u8 taskId)
+{
+    DestroyListMenuTask(gTasks[taskId].data[0], NULL, NULL);
+    RemoveWindow(gTasks[taskId].data[1]);
+    DestroyTask(taskId);
+}
+static void Debug_DestroyMenu_Full(u8 taskId)
+{
+    if (gTasks[taskId].data[2] != 0)
+    {
+        ClearStdWindowAndFrame(gTasks[taskId].data[2], FALSE);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+    DestroyListMenuTask(gTasks[taskId].data[0], NULL, NULL);
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+    DestroyTask(taskId);
+    UnfreezeObjectEvents();
+    Free(sDebugMenuListData);
+    Free(sDebugBattleData);
+}
+static void DebugAction_Cancel(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_DestroyExtraWindow(u8 taskId)
+{
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[2], TRUE);
+    RemoveWindow(gTasks[taskId].data[2]);
+
+    DestroyTask(taskId);
+    ScriptContext_Enable();
+    UnfreezeObjectEvents();
+}
+
+static u8 Debug_CheckToggleFlags(u8 id)
+{
+    u8 result = FALSE;
+
+    switch (id)
+    {
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKEDEX:
+            result = FlagGet(FLAG_SYS_POKEDEX_GET);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_NATDEX:
+            result = IsNationalPokedexEnabled();
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_POKENAV:
+            result = FlagGet(FLAG_SYS_POKENAV_GET);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_RUN_SHOES:
+            result = FlagGet(FLAG_SYS_B_DASH);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_LOCATIONS:
+            result = FlagGet(FLAG_VISITED_LITTLEROOT_TOWN) &&
+                FlagGet(FLAG_VISITED_OLDALE_TOWN) &&
+                FlagGet(FLAG_VISITED_DEWFORD_TOWN) &&
+                FlagGet(FLAG_VISITED_LAVARIDGE_TOWN) &&
+                FlagGet(FLAG_VISITED_FALLARBOR_TOWN) &&
+                FlagGet(FLAG_VISITED_VERDANTURF_TOWN) &&
+                FlagGet(FLAG_VISITED_PACIFIDLOG_TOWN) &&
+                FlagGet(FLAG_VISITED_PETALBURG_CITY) &&
+                FlagGet(FLAG_VISITED_SLATEPORT_CITY) &&
+                FlagGet(FLAG_VISITED_MAUVILLE_CITY) &&
+                FlagGet(FLAG_VISITED_RUSTBORO_CITY) &&
+                FlagGet(FLAG_VISITED_FORTREE_CITY) &&
+                FlagGet(FLAG_VISITED_LILYCOVE_CITY) &&
+                FlagGet(FLAG_VISITED_MOSSDEEP_CITY) &&
+                FlagGet(FLAG_VISITED_SOOTOPOLIS_CITY) &&
+                FlagGet(FLAG_VISITED_EVER_GRANDE_CITY) &&
+                FlagGet(FLAG_LANDMARK_POKEMON_LEAGUE) &&
+                FlagGet(FLAG_LANDMARK_BATTLE_FRONTIER);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BADGES_ALL:
+            result = FlagGet(FLAG_BADGE01_GET) &&
+                FlagGet(FLAG_BADGE02_GET) &&
+                FlagGet(FLAG_BADGE03_GET) &&
+                FlagGet(FLAG_BADGE04_GET) &&
+                FlagGet(FLAG_BADGE05_GET) &&
+                FlagGet(FLAG_BADGE06_GET) &&
+                FlagGet(FLAG_BADGE07_GET) &&
+                FlagGet(FLAG_BADGE08_GET);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_FRONTIER_PASS:
+            result = FlagGet(FLAG_SYS_FRONTIER_PASS);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BATTLE_DMG:
+            result = FlagGet(FLAG_SYS_NO_BATTLE_DMG);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_COLISSION:
+            result = FlagGet(FLAG_SYS_NO_COLLISION);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_ENCOUNTER:
+            result = FlagGet(FLAG_SYS_NO_ENCOUNTER);
+            break; 
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_TRAINER_SEE:
+            result = FlagGet(FLAG_SYS_NO_TRAINER_SEE);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_BAG_USE:
+            result = FlagGet(FLAG_SYS_NO_BAG_USE);
+            break;
+        case DEBUG_FLAGVAR_MENU_ITEM_TOGGLE_CATCHING:
+            result = FlagGet(FLAG_SYS_NO_CATCHING);
+            break;
+        default:
+            result = 0xFF;
+            break;
+    }
+
+    return result;
+}
+
+static void Debug_InitDebugBattleData(void)
+{
+    u32 i;
+    sDebugBattleData->submenu       = 0;
+    sDebugBattleData->battleType    = 0xFF;
+    sDebugBattleData->battleTerrain = 0xFF;
+    
+#ifdef BATTLE_ENGINE
+    for (i = 0; i < 17; i++)
+        sDebugBattleData->aiFlags[i] = FALSE;
+#else
+    for (i = 0; i < 10; i++)
+        sDebugBattleData->aiFlags[i] = FALSE;
+#endif
+}
+
+static void Debug_RefreshListMenu(u8 taskId)
+{
+    u16 i;
+    const u8 sColor_Red[] = _("{COLOR RED}");
+    const u8 sColor_Green[] = _("{COLOR GREEN}");
+    u8 listTaskId = gTasks[taskId].data[0];
+    struct ListMenu *list = (void*) gTasks[listTaskId].data;
+    u8 totalItems, flagResult;
+    u8 const * name;
+
+    if (sDebugMenuListData->listId == 0)
+    {
+        gMultiuseListMenuTemplate = sDebugMenu_ListTemplate_FlagsVars;
+        totalItems = gMultiuseListMenuTemplate.totalItems;
+    }
+    else if (sDebugMenuListData->listId == 1 && sDebugBattleData->submenu <= 1)
+    {
+        gMultiuseListMenuTemplate = sDebugMenu_ListTemplate_Battle_1;
+        totalItems = gMultiuseListMenuTemplate.totalItems;
+    }
+    else if (sDebugMenuListData->listId == 1 && sDebugBattleData->submenu > 1)
+    {
+        gMultiuseListMenuTemplate = sDebugMenu_ListTemplate_Battle_2;
+        totalItems = 7;
+    }
+
+    // Copy item names for all entries but the last (which is Cancel)
+    for(i = 0; i < totalItems; i++)
+    {
+        
+        if (sDebugMenuListData->listId == 1 && sDebugBattleData->submenu > 1)
+        {
+            u16 species;
+            if (i == 6)
+            {
+                name = sDebugText_Continue;
+                StringCopy(&sDebugMenuListData->itemNames[i][0], name);
+            }
+            else if (GetMonData(&gEnemyParty[i], MON_DATA_SANITY_HAS_SPECIES))
+            {
+                species = GetMonData(&gEnemyParty[i], MON_DATA_SPECIES);
+                GetSpeciesName(gStringVar1, species);
+                StringCopy(&sDebugMenuListData->itemNames[i][0], gStringVar1);
+            }
+            else
+            {
+                StringCopy(&sDebugMenuListData->itemNames[i][0], sDebugText_Dashes);
+            }
+        }
+        else
+        {
+            if (sDebugMenuListData->listId == 0)
+            {
+                flagResult = Debug_CheckToggleFlags(i);
+                name = sDebugMenu_Items_FlagsVars[i].name;
+            }
+            else if (sDebugMenuListData->listId == 1)
+            {
+                flagResult = sDebugBattleData->aiFlags[i];
+                if (i == totalItems - 1)
+                    flagResult == 0xFF;
+                name = sDebugMenu_Items_Battle_1[i].name;
+            }
+        
+            if (flagResult == 0xFF)
+            {
+                StringCopy(&sDebugMenuListData->itemNames[i][0], name);
+            }
+            else if (flagResult)
+            {
+                StringCopy(gStringVar1, sColor_Green);
+                StringExpandPlaceholders(gStringVar4, name);
+                StringCopy(&sDebugMenuListData->itemNames[i][0], gStringVar4);
+            }
+            else
+            {
+                StringCopy(gStringVar1, sColor_Red);
+                StringExpandPlaceholders(gStringVar4, name);
+                StringCopy(&sDebugMenuListData->itemNames[i][0], gStringVar4);
+            }
+        }
+
+        sDebugMenuListData->listItems[i].name = &sDebugMenuListData->itemNames[i][0];
+        sDebugMenuListData->listItems[i].id = i;
+    }
+
+    // Set list menu data
+    gMultiuseListMenuTemplate.items = sDebugMenuListData->listItems;
+    gMultiuseListMenuTemplate.totalItems = totalItems;
+    gMultiuseListMenuTemplate.maxShowed = DEBUG_MENU_HEIGHT_MAIN;
+    gMultiuseListMenuTemplate.windowId = gTasks[taskId].data[1];
+    gMultiuseListMenuTemplate.header_X = 0;
+    gMultiuseListMenuTemplate.item_X = 8;
+    gMultiuseListMenuTemplate.cursor_X = 0;
+    gMultiuseListMenuTemplate.upText_Y = 1;
+    gMultiuseListMenuTemplate.cursorPal = 2;
+    gMultiuseListMenuTemplate.fillValue = 1;
+    gMultiuseListMenuTemplate.cursorShadowPal = 3;
+    gMultiuseListMenuTemplate.lettersSpacing = 1;
+    gMultiuseListMenuTemplate.itemVerticalPadding = 0;
+    gMultiuseListMenuTemplate.scrollMultiple = LIST_NO_MULTIPLE_SCROLL;
+    gMultiuseListMenuTemplate.fontId = 1;
+    gMultiuseListMenuTemplate.cursorKind = 0;
+}
+static void Debug_RedrawListMenu(u8 taskId)
+{
+    u8 listTaskId = gTasks[taskId].data[0];
+    u16 scrollOffset, selectedRow;
+    ListMenuGetScrollAndRow(listTaskId, &scrollOffset, &selectedRow);
+
+    DestroyListMenuTask(gTasks[taskId].data[0], &scrollOffset, &selectedRow);
+    Debug_RefreshListMenu(taskId);
+    gTasks[taskId].data[0] = ListMenuInit(&gMultiuseListMenuTemplate, scrollOffset, selectedRow);
+}
+
+
+// *******************************
+// Handle Inputs
+static void DebugTask_HandleMenuInput_Main(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Main[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu_Full(taskId);
+        ScriptContext_Enable();
+    }
+}
+static void DebugTask_HandleMenuInput_Utilities(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Utilities[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+static void DebugTask_HandleMenuInput_Scripts(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Scripts[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+static void DebugTask_HandleMenuInput_FlagsVars(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {        
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Flags[input]) != NULL)
+        {
+            func(taskId);
+            Debug_RedrawListMenu(taskId);
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        
+        ClearStdWindowAndFrame(gTasks[taskId].data[2], TRUE);
+        RemoveWindow(gTasks[taskId].data[2]);
+
+        Debug_ReShowMainMenu();
+    }
+}
+
+static void DebugTask_HandleBattleMenuReDraw(u8 taskId)
+{
+    Debug_RefreshListMenu(taskId);
+    switch (sDebugBattleData->submenu)
+    {
+    case 0:
+        Debug_DestroyMenu(taskId);
+        Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, sDebugMenu_ListTemplate_Battle_0);
+        break;
+    case 1:
+        Debug_DestroyMenu(taskId);
+        Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, gMultiuseListMenuTemplate);
+        break;
+    case 2:
+        Debug_DestroyMenu(taskId);
+        Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, sDebugMenu_ListTemplate_Battle_2);
+        break;
+    case 3:
+        Debug_DestroyMenu(taskId);
+        Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, gMultiuseListMenuTemplate);
+        break;
+    }
+}
+static void DebugTask_HandleMenuInput_Battle(u8 taskId)
+{
+    void (*func)(u8);
+    u8 listTaskId = gTasks[taskId].data[0];
+    u32 input = ListMenu_ProcessInput(listTaskId);
+    u16 idx;
+
+    ListMenuGetCurrentItemArrayId(listTaskId, &idx);
+
+    if (gMain.newKeys & A_BUTTON)
+    {        
+        PlaySE(SE_SELECT);
+
+        switch (sDebugBattleData->submenu)
+        {
+        case 0: // Battle type
+            sDebugBattleData->battleType = idx;
+            sDebugBattleData->submenu++;
+            Debug_DestroyMenu(taskId);
+
+            if (sDebugBattleData->battleType == DEBUG_BATTLE_0_MENU_ITEM_WILD // Skip AI Flag selection if wild battle
+                #ifdef BATTLE_ENGINE
+                || sDebugBattleData->battleType == DEBUG_BATTLE_0_MENU_ITEM_WILD_DOUBLE
+                #endif
+                )
+            {
+                sDebugBattleData->submenu++;
+                Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, sDebugMenu_ListTemplate_Battle_2);
+            }
+            else
+            {
+                Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, gMultiuseListMenuTemplate);
+            }
+            break;
+        case 1: // AI Flags
+            if (idx == sDebugMenu_ListTemplate_Battle_1.totalItems - 1)
+            {
+                sDebugBattleData->submenu++;
+                Debug_DestroyMenu(taskId);
+                Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, sDebugMenu_ListTemplate_Battle_2);
+            }
+            else
+            {
+                sDebugBattleData->aiFlags[idx] = !sDebugBattleData->aiFlags[idx];
+                Debug_RedrawListMenu(taskId);
+            }
+                
+            break;
+        case 2: // Terrain
+            sDebugBattleData->submenu++;
+            sDebugBattleData->battleTerrain = idx;
+            Debug_DestroyMenu(taskId);
+            Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, gMultiuseListMenuTemplate);
+            break;
+        case 3: // Enemy pokemon
+            if (idx == 6)
+                Debug_InitializeBattle(taskId);
+            else
+            {
+                if (GetMonData(&gEnemyParty[idx], MON_DATA_SANITY_HAS_SPECIES))
+                {
+                    Debug_DestroyMenu(taskId);
+                    DebugPkmCreator_Init(10, idx);
+                }
+                else
+                {
+                    Debug_DestroyMenu(taskId);
+                    DebugPkmCreator_Init(9, 0xFF);
+                }
+            }
+            break;
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        switch (sDebugBattleData->submenu)
+        {
+        case 0: // Return to Main menu
+            PlaySE(SE_SELECT);
+            Debug_DestroyMenu(taskId);
+            Debug_ReShowMainMenu();
+            break;
+        case 2: // Skip AI Flag selection if wild battle
+            if (sDebugBattleData->battleType == DEBUG_BATTLE_0_MENU_ITEM_WILD 
+                #ifdef BATTLE_ENGINE
+                || sDebugBattleData->battleType == DEBUG_BATTLE_0_MENU_ITEM_WILD_DOUBLE
+                #endif
+                )
+            {
+                sDebugBattleData->submenu = 0;
+            }
+            else
+                sDebugBattleData->submenu--;
+            DebugTask_HandleBattleMenuReDraw(taskId);
+            break;
+        default:
+            sDebugBattleData->submenu--;
+            DebugTask_HandleBattleMenuReDraw(taskId);
+            break;
+        }
+    }
+}
+static void Debug_InitializeBattle(u8 taskId)
+{
+    u32 i;
+    gBattleTypeFlags = 0;
+
+    // Set main battle flags
+    switch (sDebugBattleData->battleType)
+    {
+    case DEBUG_BATTLE_0_MENU_ITEM_WILD:
+        break;
+    case DEBUG_BATTLE_0_MENU_ITEM_SINGLE:
+        gBattleTypeFlags = (BATTLE_TYPE_TRAINER);
+        break;
+    case DEBUG_BATTLE_0_MENU_ITEM_DOUBLE:
+        gBattleTypeFlags = (BATTLE_TYPE_DOUBLE | BATTLE_TYPE_TWO_OPPONENTS | BATTLE_TYPE_TRAINER);
+        break;
+    case DEBUG_BATTLE_0_MENU_ITEM_MULTI:
+        gBattleTypeFlags = (BATTLE_TYPE_DOUBLE | BATTLE_TYPE_TWO_OPPONENTS | BATTLE_TYPE_TRAINER | BATTLE_TYPE_INGAME_PARTNER);
+        break;
+    }
+    
+    // Set terrain
+    gBattleTerrain = sDebugBattleData->battleTerrain;
+
+    // Set AI flags
+    for (i = 0; i < ARRAY_COUNT(sDebugBattleData->aiFlags); i++)
+    {
+        if (sDebugBattleData->aiFlags[i])
+            gDebugAIFlags |= (1 << i);
+    }
+
+    gIsDebugBattle = TRUE;
+    BattleSetup_StartTrainerBattle_Debug();
+
+
+    Debug_DestroyMenu_Full(taskId);
+}
+
+static void DebugTask_HandleMenuInput_Give(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Give[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+static void DebugTask_HandleMenuInput_PkmCreator(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_PkmCreator[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+static void DebugTask_HandleMenuInput_Fill(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Fill[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+static void DebugTask_HandleMenuInput_Sound(u8 taskId)
+{
+    void (*func)(u8);
+    u32 input = ListMenu_ProcessInput(gTasks[taskId].data[0]);
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        if ((func = sDebugMenu_Actions_Sound[input]) != NULL)
+            func(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Debug_DestroyMenu(taskId);
+        Debug_ReShowMainMenu();
+    }
+}
+
+// *******************************
+// Open sub-menus
+static void DebugAction_OpenUtilitiesMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Utilities, sDebugMenu_ListTemplate_Utilities);
+}
+static void DebugAction_OpenScriptsMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Scripts, sDebugMenu_ListTemplate_Scripts);
+}
+static void DebugAction_OpenFlagsVarsMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    sDebugMenuListData->listId = 0;
+    Debug_ShowMenu(DebugTask_HandleMenuInput_FlagsVars, gMultiuseListMenuTemplate);
+}
+static void DebugAction_OpenBattleMenu(u8 taskId)
+{
+    // Clean enemy party
+    //u32 i;
+    //for (i = 0; i < PARTY_SIZE; i++)
+    //    ZeroMonData(&gEnemyParty[i]);
+    Debug_DestroyMenu(taskId);
+    sDebugMenuListData->listId = 1;
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Battle, sDebugMenu_ListTemplate_Battle_0);
+}
+static void DebugAction_OpenGiveMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Give, sDebugMenu_ListTemplate_Give);
+}
+static void DebugAction_OpenPokemonCreator(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_PkmCreator, sDebugMenu_ListTemplate_PkmCreator);
+}
+static void DebugAction_OpenFillMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Fill, sDebugMenu_ListTemplate_Fill);
+}
+static void DebugAction_OpenSoundMenu(u8 taskId)
+{
+    Debug_DestroyMenu(taskId);
+    Debug_ShowMenu(DebugTask_HandleMenuInput_Sound, sDebugMenu_ListTemplate_Sound);
+}
+
+// *******************************
+// Actions Utilities
+static void DebugAction_Util_HealParty(u8 taskId)
+{
+    PlaySE(SE_USE_ITEM);
+    HealPlayerParty();
+    ScriptContext_Enable();
+    Debug_DestroyMenu_Full(taskId);
+}
+static void DebugAction_Util_Fly(u8 taskId)
+{
+    FlagSet(FLAG_VISITED_LITTLEROOT_TOWN);
+    FlagSet(FLAG_VISITED_OLDALE_TOWN);
+    FlagSet(FLAG_VISITED_DEWFORD_TOWN);
+    FlagSet(FLAG_VISITED_LAVARIDGE_TOWN);
+    FlagSet(FLAG_VISITED_FALLARBOR_TOWN);
+    FlagSet(FLAG_VISITED_VERDANTURF_TOWN);
+    FlagSet(FLAG_VISITED_PACIFIDLOG_TOWN);
+    FlagSet(FLAG_VISITED_PETALBURG_CITY);
+    FlagSet(FLAG_VISITED_SLATEPORT_CITY);
+    FlagSet(FLAG_VISITED_MAUVILLE_CITY);
+    FlagSet(FLAG_VISITED_RUSTBORO_CITY);
+    FlagSet(FLAG_VISITED_FORTREE_CITY);
+    FlagSet(FLAG_VISITED_LILYCOVE_CITY);
+    FlagSet(FLAG_VISITED_MOSSDEEP_CITY);
+    FlagSet(FLAG_VISITED_SOOTOPOLIS_CITY);
+    FlagSet(FLAG_VISITED_EVER_GRANDE_CITY);
+    FlagSet(FLAG_LANDMARK_POKEMON_LEAGUE);
+    FlagSet(FLAG_LANDMARK_BATTLE_FRONTIER);
+    Debug_DestroyMenu_Full(taskId);
+    SetMainCallback2(CB2_OpenFlyMap);
+}
+
+static void DebugAction_Util_Warp_Warp(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+
+    ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+    ConvertIntToDecimalStringN(gStringVar2, MAP_GROUPS_COUNT-1, STR_CONV_MODE_LEADING_ZEROS, 2);
+    StringExpandPlaceholders(gStringVar1, sDebugText_Util_WarpToMap_SelMax);
+    StringCopy(gStringVar3, gText_DigitIndicator[0]);
+    StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectMapGroup);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    gTasks[taskId].func = DebugAction_Util_Warp_SelectMapGroup;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 0;            //Current Flag
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+    gTasks[taskId].data[5] = 0; //Map Group
+    gTasks[taskId].data[6] = 0; //Map
+    gTasks[taskId].data[7] = 0; //warp
+}
+static void DebugAction_Util_Warp_SelectMapGroup(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > MAP_GROUPS_COUNT-1)
+                gTasks[taskId].data[3] = MAP_GROUPS_COUNT-1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        ConvertIntToDecimalStringN(gStringVar2, MAP_GROUPS_COUNT-1, STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringExpandPlaceholders(gStringVar1, sDebugText_Util_WarpToMap_SelMax);
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectMapGroup);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        gTasks[taskId].data[5] = gTasks[taskId].data[3];
+        gTasks[taskId].data[3] = 0;
+        gTasks[taskId].data[4] = 0;
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        ConvertIntToDecimalStringN(gStringVar2, MAP_GROUP_COUNT[gTasks[taskId].data[5]]-1, STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringExpandPlaceholders(gStringVar1, sDebugText_Util_WarpToMap_SelMax);
+        GetMapName(gStringVar2, Overworld_GetMapHeaderByGroupAndId(gTasks[taskId].data[5], gTasks[taskId].data[3])->regionMapSectionId, 0);
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectMap);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Util_Warp_SelectMap;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Util_Warp_SelectMap(u8 taskId)
+{
+    u8 max_value = MAP_GROUP_COUNT[gTasks[taskId].data[5]]; //maps in the selected map group
+
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > max_value-1)
+                gTasks[taskId].data[3] = max_value-1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        ConvertIntToDecimalStringN(gStringVar2, MAP_GROUP_COUNT[gTasks[taskId].data[5]]-1, STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringExpandPlaceholders(gStringVar1, sDebugText_Util_WarpToMap_SelMax);
+        GetMapName(gStringVar2, Overworld_GetMapHeaderByGroupAndId(gTasks[taskId].data[5], gTasks[taskId].data[3])->regionMapSectionId, 0);
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectMap);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        gTasks[taskId].data[6] = gTasks[taskId].data[3];
+        gTasks[taskId].data[3] = 0;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectWarp);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+        gTasks[taskId].func = DebugAction_Util_Warp_SelectWarp;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Util_Warp_SelectWarp(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > 10)
+                gTasks[taskId].data[3] = 10;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_WarpToMap_SelectWarp);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        gTasks[taskId].data[7] = gTasks[taskId].data[3];
+        //WARP
+        SetWarpDestinationToMapWarp(gTasks[taskId].data[5], gTasks[taskId].data[6], gTasks[taskId].data[7]); //If not warp with the number available -> center of map
+        DoWarp();
+        ResetInitialPlayerAvatarState();
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+
+static void DebugAction_Util_PoisonMons(u8 taskId)
+{
+    int i;
+    for (i = 0; i < PARTY_SIZE; i++)
+    {
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, 0)
+            && GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_NONE
+            && GetMonData(&gPlayerParty[i], MON_DATA_SPECIES_OR_EGG) != SPECIES_EGG)
+        {
+            u32 curStatus = STATUS1_POISON;
+            SetMonData(&gPlayerParty[i], MON_DATA_STATUS, &curStatus);
+        }
+    }
+    PlaySE(SE_FIELD_POISON);
+}
+
+static void DebugAction_Util_CheckSaveBlock(u8 taskId)
+{
+    static const u8 sDebugText_SaveBlockSize[] =  _("SaveBlock1 is {STR_VAR_1} bytes long.\nMax size is 15872 bytes.\pSaveBlock2 is {STR_VAR_2} bytes long.\nMax size is 3968 bytes.\pPokemonStorage is {STR_VAR_3} bytes long.\nMax size is 35712 bytes.");
+
+    ConvertIntToDecimalStringN(gStringVar1, sizeof(struct SaveBlock1), STR_CONV_MODE_LEFT_ALIGN, 6);
+    ConvertIntToDecimalStringN(gStringVar2, sizeof(struct SaveBlock2), STR_CONV_MODE_LEFT_ALIGN, 6);
+    ConvertIntToDecimalStringN(gStringVar3, sizeof(struct PokemonStorage), STR_CONV_MODE_LEFT_ALIGN, 6);
+    StringExpandPlaceholders(gStringVar4, sDebugText_SaveBlockSize);
+
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_ShowFieldMessageStringVar4);
+}
+
+static const u8 sWeatherNames[22][24] = {
+    [WEATHER_NONE]               = _("NONE"),
+    [WEATHER_SUNNY_CLOUDS]       = _("SUNNY CLOUDS"),
+    [WEATHER_SUNNY]              = _("SUNNY"),
+    [WEATHER_RAIN]               = _("RAIN"),
+    [WEATHER_SNOW]               = _("SNOW"),
+    [WEATHER_RAIN_THUNDERSTORM]  = _("RAIN THUNDERSTORM"),
+    [WEATHER_FOG_HORIZONTAL]     = _("FOG HORIZONTAL"),
+    [WEATHER_VOLCANIC_ASH]       = _("VOLCANIC ASH"),
+    [WEATHER_SANDSTORM]          = _("SANDSTORM"),
+    [WEATHER_FOG_DIAGONAL]       = _("FOG DIAGONAL"),
+    [WEATHER_UNDERWATER]         = _("UNDERWATER"),
+    [WEATHER_SHADE]              = _("SHADE"),
+    [WEATHER_DROUGHT]            = _("DROUGHT"),
+    [WEATHER_DOWNPOUR]           = _("DOWNPOUR"),
+    [WEATHER_UNDERWATER_BUBBLES] = _("UNDERWATER BUBBLES"),
+    [WEATHER_ABNORMAL]           = _("ABNORMAL(NOT WORKING)"),
+    [WEATHER_ROUTE119_CYCLE]     = _("ROUTE119 CYCLE"),
+    [WEATHER_ROUTE123_CYCLE]     = _("ROUTE123 CYCLE"),
+};
+static const u8 sText_WeatherNotDefined[] = _("NOT DEFINED!!!");
+static void DebugAction_Util_Weather(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateWeather);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, 1, STR_CONV_MODE_LEADING_ZEROS, 2);
+    StringCopyPadded(gStringVar1, sWeatherNames[0], CHAR_SPACE, 30);
+    StringExpandPlaceholders(gStringVar4, sDebugText_Util_Weather_ID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    gTasks[taskId].func = DebugAction_Util_Weather_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 0;            //Current ID
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+}
+static void DebugAction_Util_Weather_SelectId(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > WEATHER_ROUTE123_CYCLE)
+                gTasks[taskId].data[3] = WEATHER_ROUTE123_CYCLE;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < WEATHER_NONE)
+                gTasks[taskId].data[3] = WEATHER_NONE;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+
+        if (gTasks[taskId].data[3] <= 15 || gTasks[taskId].data[3] >= 20)
+            StringCopyPadded(gStringVar1, sWeatherNames[gTasks[taskId].data[3]], CHAR_SPACE, 30);
+        else
+            StringCopyPadded(gStringVar1, sText_WeatherNotDefined, CHAR_SPACE, 30); 
+
+        StringExpandPlaceholders(gStringVar4, sDebugText_Util_Weather_ID);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        if (gTasks[taskId].data[3] <= 14 || gTasks[taskId].data[3] >= 20)
+        {
+            gTasks[taskId].data[5] = gTasks[taskId].data[3];
+            SetWeather(gTasks[taskId].data[5]);
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+
+static void DebugAction_Util_CheckWallClock(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(PlayersHouse_2F_EventScript_CheckWallClock);
+}
+static void DebugAction_Util_SetWallClock(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(PlayersHouse_2F_EventScript_SetWallClock);
+}
+static void DebugAction_Util_WatchCredits(u8 taskId)
+{
+    struct Task* task = &gTasks[taskId];
+    Debug_DestroyMenu_Full(taskId);
+    SetMainCallback2(CB2_StartCreditsSequence);
+}
+static void DebugAction_Util_Trainer_Name(u8 taskId)
+{
+    NewGameBirchSpeech_SetDefaultPlayerName(Random() % 20);
+    DoNamingScreen(0, gSaveBlock2Ptr->playerName, gSaveBlock2Ptr->playerGender, 0, 0, CB2_ReturnToFieldContinueScript);
+}
+static void DebugAction_Util_Trainer_Gender(u8 taskId)
+{
+    if (gSaveBlock2Ptr->playerGender == 0) // 0 Male, 1 Female
+        gSaveBlock2Ptr->playerGender = 1;
+    else
+        gSaveBlock2Ptr->playerGender = 0;
+    ScriptContext_Enable();
+    Debug_DestroyMenu_Full(taskId);
+}
+static void DebugAction_Util_Trainer_Id(u8 taskId)
+{
+    u32 trainerId = ((Random() << 16) | Random());
+    SetTrainerId(trainerId, gSaveBlock2Ptr->playerTrainerId);
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_Util_CheatStart(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_CheatStart);
+}
+
+// *******************************
+// Actions Scripts
+static void DebugAction_Util_Script_1(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_1);
+}
+static void DebugAction_Util_Script_2(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_2);
+}
+static void DebugAction_Util_Script_3(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_3);
+}
+static void DebugAction_Util_Script_4(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_4);
+}
+static void DebugAction_Util_Script_5(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_5);
+}
+static void DebugAction_Util_Script_6(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_6);
+}
+static void DebugAction_Util_Script_7(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_7);
+}
+static void DebugAction_Util_Script_8(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    ScriptContext_SetupScript(Debug_Script_8);
+}
+
+// *******************************
+// Actions Flags and Vars
+static void DebugAction_FlagsVars_Flags(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial Flag
+    ConvertIntToDecimalStringN(gStringVar1, 1, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_FLAGS);
+    ConvertIntToHexStringN(gStringVar2, 1, STR_CONV_MODE_LEFT_ALIGN, 3);
+    StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_FlagHex);
+    if (FlagGet(FLAG_TEMP_1))
+        StringCopyPadded(gStringVar2, sDebugText_True, CHAR_SPACE, 15);
+    else
+        StringCopyPadded(gStringVar2, sDebugText_False, CHAR_SPACE, 15);
+    StringCopy(gStringVar3, gText_DigitIndicator[0]);
+    StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_Flag);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    gTasks[taskId].func = DebugAction_FlagsVars_FlagsSelect;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = FLAG_TEMP_1; //Current Flag
+    gTasks[taskId].data[4] = 0;           //Digit Selected
+}
+static void DebugAction_FlagsVars_FlagsSelect(u8 taskId)
+{
+    if (gMain.newKeys & A_BUTTON)
+        FlagToggle(gTasks[taskId].data[3]);
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+        return;
+    }
+
+    if (gMain.newKeys & DPAD_UP)
+    {
+        PlaySE(SE_SELECT);
+        gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+        if (gTasks[taskId].data[3] >= FLAGS_COUNT){
+            gTasks[taskId].data[3] = FLAGS_COUNT - 1;
+        }
+    }
+    if (gMain.newKeys & DPAD_DOWN)
+    {
+        PlaySE(SE_SELECT);
+        gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+        if (gTasks[taskId].data[3] < 1){
+            gTasks[taskId].data[3] = 1;
+        }
+    }
+    if (gMain.newKeys & DPAD_LEFT)
+    {
+        PlaySE(SE_SELECT);
+        gTasks[taskId].data[4] -= 1;
+        if (gTasks[taskId].data[4] < 0)
+        {
+            gTasks[taskId].data[4] = 0;
+        }
+    }
+    if (gMain.newKeys & DPAD_RIGHT)
+    {
+        PlaySE(SE_SELECT);
+        gTasks[taskId].data[4] += 1;
+        if (gTasks[taskId].data[4] > DEBUG_NUMBER_DIGITS_FLAGS-1)
+        {
+            gTasks[taskId].data[4] = DEBUG_NUMBER_DIGITS_FLAGS-1;
+        }
+    }
+
+    if (gMain.newKeys & DPAD_ANY || gMain.newKeys & A_BUTTON)
+    {
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_FLAGS);
+        ConvertIntToHexStringN(gStringVar2, gTasks[taskId].data[3], STR_CONV_MODE_LEFT_ALIGN, 3);
+        StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_FlagHex);
+        if (FlagGet(gTasks[taskId].data[3]) == TRUE)
+            StringCopyPadded(gStringVar2, sDebugText_True, CHAR_SPACE, 15);
+        else
+            StringCopyPadded(gStringVar2, sDebugText_False, CHAR_SPACE, 15);
+        StringCopy(gStringVar3, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_Flag);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+}
+
+static void DebugAction_FlagsVars_Vars(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial Variable
+    ConvertIntToDecimalStringN(gStringVar1, VARS_START, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+    ConvertIntToHexStringN(gStringVar2, VARS_START, STR_CONV_MODE_LEFT_ALIGN, 4);
+    StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_VariableHex);
+    ConvertIntToDecimalStringN(gStringVar3, 0, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+    StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_Variable);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    gTasks[taskId].func = DebugAction_FlagsVars_Select;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = VARS_START;            //Current Variable
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+    gTasks[taskId].data[5] = 0;            //Current Variable VALUE
+}
+
+static void DebugAction_FlagsVars_Select(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_UP)
+    {
+        gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+        if (gTasks[taskId].data[3] > VARS_END){
+            gTasks[taskId].data[3] = VARS_END;
+        }
+    }
+    if (gMain.newKeys & DPAD_DOWN)
+    {
+        gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+        if (gTasks[taskId].data[3] < VARS_START){
+            gTasks[taskId].data[3] = VARS_START;
+        }
+    }
+    if (gMain.newKeys & DPAD_LEFT)
+    {
+        gTasks[taskId].data[4] -= 1;
+        if (gTasks[taskId].data[4] < 0)
+        {
+            gTasks[taskId].data[4] = 0;
+        }
+    }
+    if (gMain.newKeys & DPAD_RIGHT)
+    {
+        gTasks[taskId].data[4] += 1;
+        if (gTasks[taskId].data[4] > DEBUG_NUMBER_DIGITS_VARIABLES-1)
+        {
+            gTasks[taskId].data[4] = DEBUG_NUMBER_DIGITS_VARIABLES-1;
+        }
+    }
+
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        ConvertIntToHexStringN(gStringVar2, gTasks[taskId].data[3], STR_CONV_MODE_LEFT_ALIGN, 4);
+        StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_VariableHex);
+        if (VarGetIfExist(gTasks[taskId].data[3]) == 65535) //Current value, if 65535 the value hasnt been set
+            gTasks[taskId].data[5] = 0;
+        else
+            gTasks[taskId].data[5] = VarGet(gTasks[taskId].data[3]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[5], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]); //Current digit
+
+        //Combine str's to full window string
+        StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_Variable);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        gTasks[taskId].data[4] = 0;
+
+        PlaySE(SE_SELECT);
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        ConvertIntToHexStringN(gStringVar2, gTasks[taskId].data[3], STR_CONV_MODE_LEFT_ALIGN, 4);
+        StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_VariableHex);
+        if (VarGetIfExist(gTasks[taskId].data[3]) == 65535) //Current value if 65535 the value hasnt been set
+            gTasks[taskId].data[5] = 0;
+        else
+            gTasks[taskId].data[5] = VarGet(gTasks[taskId].data[3]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[5], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]); //Current digit
+        StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_VariableValueSet);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].data[6] = gTasks[taskId].data[5]; //New value selector
+        gTasks[taskId].func = DebugAction_FlagsVars_SetValue;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+        return;
+    }
+}
+static void DebugAction_FlagsVars_SetValue(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_UP)
+    {
+        if (gTasks[taskId].data[6] + sPowersOfTen[gTasks[taskId].data[4]] <= 32000)
+            gTasks[taskId].data[6] += sPowersOfTen[gTasks[taskId].data[4]];
+        else
+            gTasks[taskId].data[6] = 32000-1;
+        if (gTasks[taskId].data[6] >= 32000){
+            gTasks[taskId].data[6] = 32000-1;
+        }
+    }
+    if (gMain.newKeys & DPAD_DOWN)
+    {
+        gTasks[taskId].data[6] -= sPowersOfTen[gTasks[taskId].data[4]];
+        if (gTasks[taskId].data[6] < 0){
+            gTasks[taskId].data[6] = 0;
+        }
+    }
+    if (gMain.newKeys & DPAD_LEFT)
+    {
+        gTasks[taskId].data[4] -= 1;
+        if (gTasks[taskId].data[4] < 0)
+        {
+            gTasks[taskId].data[4] = 0;
+        }
+    }
+    if (gMain.newKeys & DPAD_RIGHT)
+    {
+        gTasks[taskId].data[4] += 1;
+        if (gTasks[taskId].data[4] > 4)
+        {
+            gTasks[taskId].data[4] = 4;
+        }
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        VarSet(gTasks[taskId].data[3], gTasks[taskId].data[6]);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+        return;
+    }
+
+    if (gMain.newKeys & DPAD_ANY || gMain.newKeys & A_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        ConvertIntToHexStringN(gStringVar2, gTasks[taskId].data[3], STR_CONV_MODE_LEFT_ALIGN, 4);
+        StringExpandPlaceholders(gStringVar1, sDebugText_FlagsVars_VariableHex);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[6], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_VARIABLES);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]); //Current digit
+        StringExpandPlaceholders(gStringVar4, sDebugText_FlagsVars_VariableValueSet);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+}
+
+static void DebugAction_FlagsVars_PokedexFlags_All(u8 taskId)
+{
+    u16 i;
+    for (i = 0; i < NATIONAL_DEX_COUNT; i++)
+    {
+        GetSetPokedexFlag(i + 1, FLAG_SET_CAUGHT);
+        GetSetPokedexFlag(i + 1, FLAG_SET_SEEN);
+    }
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_FlagsVars_PokedexFlags_Reset(u8 taskId)
+{
+    int boxId, boxPosition, partyId;
+    u16 species;
+
+    // Reset Pokedex to emtpy
+    memset(&gSaveBlock2Ptr->pokedex.owned, 0, sizeof(gSaveBlock2Ptr->pokedex.owned));
+    memset(&gSaveBlock2Ptr->pokedex.seen, 0, sizeof(gSaveBlock2Ptr->pokedex.seen));
+
+    // Add party Pokemon to Pokedex
+    for (partyId = 0; partyId < PARTY_SIZE; partyId++)
+    {
+        if (GetMonData(&gPlayerParty[partyId], MON_DATA_SANITY_HAS_SPECIES))
+        {
+            species = GetMonData(&gPlayerParty[partyId], MON_DATA_SPECIES);
+            GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_SET_CAUGHT);
+            GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_SET_SEEN);
+        }
+    }
+
+    // Add box Pokemon to Pokedex
+    for (boxId = 0; boxId < TOTAL_BOXES_COUNT; boxId++)
+    {
+        for (boxPosition = 0; boxPosition < IN_BOX_COUNT; boxPosition++)
+        {
+            if (GetBoxMonData(&gPokemonStoragePtr->boxes[boxId][boxPosition], MON_DATA_SANITY_HAS_SPECIES))
+            {
+                species = GetBoxMonData(&gPokemonStoragePtr->boxes[boxId][boxPosition], MON_DATA_SPECIES);
+                GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_SET_CAUGHT);
+                GetSetPokedexFlag(SpeciesToNationalPokedexNum(species), FLAG_SET_SEEN);
+            }
+        }
+    }
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_FlagsVars_SwitchDex(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_POKEDEX_GET))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_POKEDEX_GET);
+}
+static void DebugAction_FlagsVars_SwitchNatDex(u8 taskId)
+{
+    if (IsNationalPokedexEnabled())
+    {
+        DisableNationalPokedex();
+        PlaySE(SE_PC_OFF);
+    }else{
+        EnableNationalPokedex();
+        PlaySE(SE_PC_LOGIN);
+    }
+}
+static void DebugAction_FlagsVars_SwitchPokeNav(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_POKENAV_GET))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_POKENAV_GET);
+}
+static void DebugAction_FlagsVars_RunningShoes(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_B_DASH))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_B_DASH);
+}
+static void DebugAction_FlagsVars_ToggleFlyFlags(u8 taskId)
+{
+    // Sound effect
+    if (FlagGet(FLAG_LANDMARK_BATTLE_FRONTIER))
+    {
+        PlaySE(SE_PC_OFF);
+
+        FlagClear(FLAG_VISITED_LITTLEROOT_TOWN);
+        FlagClear(FLAG_VISITED_OLDALE_TOWN);
+        FlagClear(FLAG_VISITED_DEWFORD_TOWN);
+        FlagClear(FLAG_VISITED_LAVARIDGE_TOWN);
+        FlagClear(FLAG_VISITED_FALLARBOR_TOWN);
+        FlagClear(FLAG_VISITED_VERDANTURF_TOWN);
+        FlagClear(FLAG_VISITED_PACIFIDLOG_TOWN);
+        FlagClear(FLAG_VISITED_PETALBURG_CITY);
+        FlagClear(FLAG_VISITED_SLATEPORT_CITY);
+        FlagClear(FLAG_VISITED_MAUVILLE_CITY);
+        FlagClear(FLAG_VISITED_RUSTBORO_CITY);
+        FlagClear(FLAG_VISITED_FORTREE_CITY);
+        FlagClear(FLAG_VISITED_LILYCOVE_CITY);
+        FlagClear(FLAG_VISITED_MOSSDEEP_CITY);
+        FlagClear(FLAG_VISITED_SOOTOPOLIS_CITY);
+        FlagClear(FLAG_VISITED_EVER_GRANDE_CITY);
+        FlagClear(FLAG_LANDMARK_POKEMON_LEAGUE);
+        FlagClear(FLAG_LANDMARK_BATTLE_FRONTIER);
+    }
+    else
+    {
+        PlaySE(SE_PC_LOGIN);
+    
+        FlagSet(FLAG_VISITED_LITTLEROOT_TOWN);
+        FlagSet(FLAG_VISITED_OLDALE_TOWN);
+        FlagSet(FLAG_VISITED_DEWFORD_TOWN);
+        FlagSet(FLAG_VISITED_LAVARIDGE_TOWN);
+        FlagSet(FLAG_VISITED_FALLARBOR_TOWN);
+        FlagSet(FLAG_VISITED_VERDANTURF_TOWN);
+        FlagSet(FLAG_VISITED_PACIFIDLOG_TOWN);
+        FlagSet(FLAG_VISITED_PETALBURG_CITY);
+        FlagSet(FLAG_VISITED_SLATEPORT_CITY);
+        FlagSet(FLAG_VISITED_MAUVILLE_CITY);
+        FlagSet(FLAG_VISITED_RUSTBORO_CITY);
+        FlagSet(FLAG_VISITED_FORTREE_CITY);
+        FlagSet(FLAG_VISITED_LILYCOVE_CITY);
+        FlagSet(FLAG_VISITED_MOSSDEEP_CITY);
+        FlagSet(FLAG_VISITED_SOOTOPOLIS_CITY);
+        FlagSet(FLAG_VISITED_EVER_GRANDE_CITY);
+        FlagSet(FLAG_LANDMARK_POKEMON_LEAGUE);
+        FlagSet(FLAG_LANDMARK_BATTLE_FRONTIER);
+    }
+}
+static void DebugAction_FlagsVars_ToggleBadgeFlags(u8 taskId)
+{
+    // Sound effect
+    if (FlagGet(FLAG_BADGE08_GET))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_BADGE01_GET);
+    FlagToggle(FLAG_BADGE02_GET);
+    FlagToggle(FLAG_BADGE03_GET);
+    FlagToggle(FLAG_BADGE04_GET);
+    FlagToggle(FLAG_BADGE05_GET);
+    FlagToggle(FLAG_BADGE06_GET);
+    FlagToggle(FLAG_BADGE07_GET);
+    FlagToggle(FLAG_BADGE08_GET);
+}
+static void DebugAction_FlagsVars_ToggleFrontierPass(u8 taskId)
+{
+    // Sound effect
+    if (FlagGet(FLAG_SYS_FRONTIER_PASS))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_FRONTIER_PASS);
+}
+static void DebugAction_FlagsVars_BattleDmgOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_BATTLE_DMG))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_BATTLE_DMG);
+}
+static void DebugAction_FlagsVars_CollisionOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_COLLISION))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_COLLISION);
+}
+static void DebugAction_FlagsVars_EncounterOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_ENCOUNTER))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_ENCOUNTER);
+}
+static void DebugAction_FlagsVars_TrainerSeeOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_TRAINER_SEE))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_TRAINER_SEE);
+}
+static void DebugAction_FlagsVars_BagUseOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_BAG_USE))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_BAG_USE);
+}
+static void DebugAction_FlagsVars_CatchingOnOff(u8 taskId)
+{
+    if (FlagGet(FLAG_SYS_NO_CATCHING))
+        PlaySE(SE_PC_OFF);
+    else
+        PlaySE(SE_PC_LOGIN);
+    FlagToggle(FLAG_SYS_NO_CATCHING);
+}
+
+// *******************************
+// Actions Give
+#define ITEM_TAG 0xFDF3
+static void DebugAction_Give_Item(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, 1, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+    CopyItemName(1, gStringVar1);
+    StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+    StringExpandPlaceholders(gStringVar4, sDebugText_ItemID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    gTasks[taskId].func = DebugAction_Give_Item_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 1;            //Current ID
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+    gTasks[taskId].data[6] = AddItemIconSprite(ITEM_TAG, ITEM_TAG, gTasks[taskId].data[3]);
+    gSprites[gTasks[taskId].data[6]].x2 = DEBUG_NUMBER_ICON_X+10;
+    gSprites[gTasks[taskId].data[6]].y2 = DEBUG_NUMBER_ICON_Y+10;
+    gSprites[gTasks[taskId].data[6]].oam.priority = 0;
+}
+static void DebugAction_Give_Item_SelectId(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] >= ITEMS_COUNT)
+                gTasks[taskId].data[3] = ITEMS_COUNT - 1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < DEBUG_NUMBER_DIGITS_ITEMS-1)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        CopyItemName(gTasks[taskId].data[3], gStringVar1);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+        StringExpandPlaceholders(gStringVar4, sDebugText_ItemID);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        FreeSpriteTilesByTag(ITEM_TAG);                         //Destroy item icon
+        FreeSpritePaletteByTag(ITEM_TAG);                       //Destroy item icon
+        FreeSpriteOamMatrix(&gSprites[gTasks[taskId].data[6]]); //Destroy item icon
+        DestroySprite(&gSprites[gTasks[taskId].data[6]]);       //Destroy item icon
+        gTasks[taskId].data[6] = AddItemIconSprite(ITEM_TAG, ITEM_TAG, gTasks[taskId].data[3]);
+        gSprites[gTasks[taskId].data[6]].x2 = DEBUG_NUMBER_ICON_X+10;
+        gSprites[gTasks[taskId].data[6]].y2 = DEBUG_NUMBER_ICON_Y+10;
+        gSprites[gTasks[taskId].data[6]].oam.priority = 0;
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        gTasks[taskId].data[5] = gTasks[taskId].data[3];
+        gTasks[taskId].data[3] = 1;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEM_QUANTITY);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_ItemQuantity);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Give_Item_SelectQuantity;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        FreeSpriteTilesByTag(ITEM_TAG);                         //Destroy item icon
+        FreeSpritePaletteByTag(ITEM_TAG);                       //Destroy item icon
+        FreeSpriteOamMatrix(&gSprites[gTasks[taskId].data[6]]); //Destroy item icon
+        DestroySprite(&gSprites[gTasks[taskId].data[6]]);       //Destroy item icon
+
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Item_SelectQuantity(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] >= 100)
+                gTasks[taskId].data[3] = 99;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEM_QUANTITY);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_ItemQuantity);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        FreeSpriteTilesByTag(ITEM_TAG);                         //Destroy item icon
+        FreeSpritePaletteByTag(ITEM_TAG);                       //Destroy item icon
+        FreeSpriteOamMatrix(&gSprites[gTasks[taskId].data[6]]); //Destroy item icon
+        DestroySprite(&gSprites[gTasks[taskId].data[6]]);       //Destroy item icon
+
+        PlaySE(MUS_OBTAIN_ITEM);
+        AddBagItem(gTasks[taskId].data[5], gTasks[taskId].data[3]);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        FreeSpriteTilesByTag(ITEM_TAG);                         //Destroy item icon
+        FreeSpritePaletteByTag(ITEM_TAG);                       //Destroy item icon
+        FreeSpriteOamMatrix(&gSprites[gTasks[taskId].data[6]]); //Destroy item icon
+        DestroySprite(&gSprites[gTasks[taskId].data[6]]);       //Destroy item icon
+
+        PlaySE(SE_SELECT);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+
+//TMs
+static void DebugAction_Give_AllTMs(u8 taskId)
+{
+    u16 i;
+    PlayFanfare(MUS_OBTAIN_TMHM);
+    for (i = ITEM_TM01; i <= ITEM_TM50; i++)
+        if (!CheckBagHasItem(i, 1))
+            AddBagItem(i, 1);
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+
+//Pokemon
+static void ResetMonDataStruct(struct DebugMonData *sDebugMonData)
+{
+    sDebugMonData->mon_speciesId    = 1;
+    sDebugMonData->mon_level        = 1;
+    sDebugMonData->isShiny          = 0;
+    sDebugMonData->mon_natureId     = 0;
+    sDebugMonData->mon_abilityNum   = 0;
+    sDebugMonData->mon_iv_hp        = 0;
+    sDebugMonData->mon_iv_atk       = 0;
+    sDebugMonData->mon_iv_def       = 0;
+    sDebugMonData->mon_iv_speed     = 0;
+    sDebugMonData->mon_iv_satk      = 0;
+    sDebugMonData->mon_iv_sdef      = 0;
+}
+static void DebugAction_Give_PokemonSimple(u8 taskId)
+{
+    u8 windowId;
+
+    //Mon data struct
+    sDebugMonData = AllocZeroed(sizeof(struct DebugMonData));
+    ResetMonDataStruct(sDebugMonData);
+
+    //Window initialization
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, 1, STR_CONV_MODE_LEADING_ZEROS, 3);
+    StringCopy(gStringVar1, gSpeciesNames[1]);
+    StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+    StringExpandPlaceholders(gStringVar4, sDebugText_PokemonID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    //Set task data
+    gTasks[taskId].func = DebugAction_Give_Pokemon_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 1;            //Current ID
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+    gTasks[taskId].data[5] = 0;            //Complex?
+    FreeMonIconPalettes();                 //Free space for new pallete
+    LoadMonIconPalette(gTasks[taskId].data[3]); //Loads pallete for current mon
+    #ifndef POKEMON_EXPANSION
+        gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0, TRUE); //Create pokemon sprite
+    #endif
+    #ifdef POKEMON_EXPANSION
+        gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0); //Create pokemon sprite
+    #endif
+    gSprites[gTasks[taskId].data[6]].oam.priority = 0; //Mon Icon ID
+}
+static void DebugAction_Give_PokemonComplex(u8 taskId)
+{
+    u8 windowId;
+
+    //Mon data struct
+    sDebugMonData = AllocZeroed(sizeof(struct DebugMonData));
+    ResetMonDataStruct(sDebugMonData);
+
+    //Window initialization
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateExtra);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, 1, STR_CONV_MODE_LEADING_ZEROS, 4);
+    StringCopy(gStringVar1, gSpeciesNames[1]);
+    StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+    StringExpandPlaceholders(gStringVar4, sDebugText_PokemonID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+
+    gTasks[taskId].func = DebugAction_Give_Pokemon_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 1;            //Current ID
+    gTasks[taskId].data[4] = 0;            //Digit Selected
+    gTasks[taskId].data[5] = 1;            //Complex?
+    FreeMonIconPalettes();                 //Free space for new palletes
+    LoadMonIconPalette(gTasks[taskId].data[3]); //Loads pallete for current mon
+    #ifndef POKEMON_EXPANSION
+        gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0, TRUE); //Create pokemon sprite
+    #endif
+    #ifdef POKEMON_EXPANSION
+        gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0); //Create pokemon sprite
+    #endif
+    gSprites[gTasks[taskId].data[6]].oam.priority = 0; //Mon Icon ID
+    gTasks[taskId].data[7] = 0;             //iterator
+}
+
+static void DebugAction_Give_Pokemon_SelectId(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > SPECIES_CELEBI && gTasks[taskId].data[3] < SPECIES_TREECKO)
+                gTasks[taskId].data[3] = SPECIES_TREECKO;
+            if (gTasks[taskId].data[3] >= NUM_SPECIES)
+                gTasks[taskId].data[3] = NUM_SPECIES - 1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < SPECIES_TREECKO && gTasks[taskId].data[3] > SPECIES_CELEBI)
+                gTasks[taskId].data[3] = SPECIES_CELEBI;
+            if (gTasks[taskId].data[3] < 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < DEBUG_NUMBER_DIGITS_ITEMS-1)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringCopy(gStringVar1, gSpeciesNames[gTasks[taskId].data[3]]); //CopyItemName(gTasks[taskId].data[3], gStringVar1);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 4);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonID);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].data[6]]);
+        FreeMonIconPalettes(); //Free space for new pallete
+        LoadMonIconPalette(gTasks[taskId].data[3]); //Loads pallete for current mon
+        #ifndef POKEMON_EXPANSION
+            gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0, TRUE); //Create pokemon sprite
+        #endif
+        #ifdef POKEMON_EXPANSION
+            gTasks[taskId].data[6] = CreateMonIcon(gTasks[taskId].data[3], SpriteCB_MonIcon, DEBUG_NUMBER_ICON_X, DEBUG_NUMBER_ICON_Y, 4, 0); //Create pokemon sprite
+        #endif
+        gSprites[gTasks[taskId].data[6]].oam.priority = 0;
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        sDebugMonData->mon_speciesId = gTasks[taskId].data[3]; //Species ID
+        gTasks[taskId].data[3] = 1;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 3);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonLevel);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Give_Pokemon_SelectLevel;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        FreeMonIconPalettes();
+        FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].data[6]]); //Destroy pokemon sprite
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_SelectLevel(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > 100)
+                gTasks[taskId].data[3] = 100;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar1, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 3);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonLevel);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        FreeMonIconPalettes();
+        FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].data[6]]); //Destroy pokemon sprite
+        if (gTasks[taskId].data[5] == 0)
+        {
+            PlaySE(MUS_LEVEL_UP);
+            ScriptGiveMon(sDebugMonData->mon_speciesId, gTasks[taskId].data[3], ITEM_NONE, 0,0,0);
+            Free(sDebugMonData); //Frees EWRAM of MonData Struct
+            DebugAction_DestroyExtraWindow(taskId);
+        }
+        else
+        {
+            sDebugMonData->mon_level = gTasks[taskId].data[3]; //Level
+            gTasks[taskId].data[3] = 0;
+            gTasks[taskId].data[4] = 0;
+
+            ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 0);
+            StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+            StringCopyPadded(gStringVar2, sDebugText_False, CHAR_SPACE, 15);
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonShiny);
+            AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+            gTasks[taskId].func = DebugAction_Give_Pokemon_SelectShiny;
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        FreeMonIconPalettes();
+        FreeAndDestroyMonIconSprite(&gSprites[gTasks[taskId].data[6]]); //Destroy pokemon sprite
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+//If complex
+static void DebugAction_Give_Pokemon_SelectShiny(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+
+        if (gTasks[taskId].data[3] == 1)
+            StringCopyPadded(gStringVar2, sDebugText_True, CHAR_SPACE, 15);
+        else
+            StringCopyPadded(gStringVar2, sDebugText_False, CHAR_SPACE, 15);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 0);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonShiny);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        sDebugMonData->isShiny = gTasks[taskId].data[3]; //isShiny
+        gTasks[taskId].data[3] = 0;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringCopy(gStringVar1, gNatureNamePointers[0]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonNature);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Give_Pokemon_SelectNature;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_SelectNature(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > NUM_NATURES-1)
+                gTasks[taskId].data[3] = NUM_NATURES-1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringCopy(gStringVar1, gNatureNamePointers[gTasks[taskId].data[3]]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonNature);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        u8 abilityId;
+        sDebugMonData->mon_natureId = gTasks[taskId].data[3]; //NatureId
+        gTasks[taskId].data[3] = 0;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        abilityId = GetAbilityBySpecies(sDebugMonData->mon_speciesId, 0);
+        StringCopy(gStringVar1, gAbilityNames[abilityId]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonAbility);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Give_Pokemon_SelectAbility;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_SelectAbility(u8 taskId)
+{
+    u8 abilityId;
+    u8 abilityCount = 2 - 1; //-1 for proper iteration
+    u8 i = 0;
+    #ifdef POKEMON_EXPANSION
+        abilityCount = NUM_ABILITY_SLOTS - 1;
+    #endif
+
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > abilityCount)
+                gTasks[taskId].data[3] = abilityCount;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+
+        while (GetAbilityBySpecies(sDebugMonData->mon_speciesId, gTasks[taskId].data[3] - i) == ABILITY_NONE)
+        {
+            i++;
+        }
+        abilityId = GetAbilityBySpecies(sDebugMonData->mon_speciesId, gTasks[taskId].data[3] - i);
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringCopy(gStringVar1, gAbilityNames[abilityId]);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonAbility);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        sDebugMonData->mon_abilityNum = gTasks[taskId].data[3] - i; //AbilityNum
+        gTasks[taskId].data[3] = 0;
+        gTasks[taskId].data[4] = 0;
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_0);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+        gTasks[taskId].func = DebugAction_Give_Pokemon_SelectIVs;
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_SelectIVs(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > 31)
+                gTasks[taskId].data[3] = 31;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 2)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+        StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+        switch (gTasks[taskId].data[7])
+        {
+        case 0:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_0);
+            break;
+        case 1:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_1);
+            break;
+        case 2:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_2);
+            break;
+        case 3:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_3);
+            break;
+        case 4:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_4);
+            break;
+        case 5:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_5);
+            break;
+        }
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    //If A or B button
+    if (gMain.newKeys & A_BUTTON)
+    {
+        switch (gTasks[taskId].data[7])
+        {
+        case 0:
+            sDebugMonData->mon_iv_hp = gTasks[taskId].data[3];
+            break;
+        case 1:
+            sDebugMonData->mon_iv_atk = gTasks[taskId].data[3];
+            break;
+        case 2:
+            sDebugMonData->mon_iv_def = gTasks[taskId].data[3];
+            break;
+        case 3:
+            sDebugMonData->mon_iv_speed = gTasks[taskId].data[3];
+            break;
+        case 4:
+            sDebugMonData->mon_iv_satk = gTasks[taskId].data[3];
+            break;
+        case 5:
+            sDebugMonData->mon_iv_sdef = gTasks[taskId].data[3];
+            break;
+        }
+
+        //Check if all IVs set
+        if (gTasks[taskId].data[7] != 5)
+        {
+            gTasks[taskId].data[7] += 1;
+            gTasks[taskId].data[3] = 0;
+            gTasks[taskId].data[4] = 0;
+
+            StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+            ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 2);
+            StringCopyPadded(gStringVar3, gStringVar3, CHAR_SPACE, 15);
+            switch (gTasks[taskId].data[7])
+            {
+            case 0:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_0);
+                break;
+            case 1:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_1);
+                break;
+            case 2:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_2);
+                break;
+            case 3:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_3);
+                break;
+            case 4:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_4);
+                break;
+            case 5:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonIV_5);
+                break;
+            }
+            AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+            gTasks[taskId].func = DebugAction_Give_Pokemon_SelectIVs;
+        }
+        else
+        {
+            gTasks[taskId].data[3] = 0;
+            gTasks[taskId].data[4] = 0;
+            gTasks[taskId].data[7] = 0; //Reset iterator
+
+            StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+            StringCopy(gStringVar1, gMoveNames[gTasks[taskId].data[3]]);
+            StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+            ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 3);
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_0);
+            AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+            gTasks[taskId].func = DebugAction_Give_Pokemon_Move;
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_Move(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        PlaySE(SE_SELECT);
+
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] >= MOVES_COUNT)
+                gTasks[taskId].data[3] = MOVES_COUNT - 1;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 0)
+                gTasks[taskId].data[3] = 0;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < 3)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringCopy(gStringVar1, gMoveNames[gTasks[taskId].data[3]]);
+        StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 3);
+        switch (gTasks[taskId].data[7])
+        {
+        case 0:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_0);
+            break;
+        case 1:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_1);
+            break;
+        case 2:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_2);
+            break;
+        case 3:
+            StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_3);
+            break;
+        }
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        //If MOVE_NONE selected, stop asking for additional moves
+        if (gTasks[taskId].data[3] == 0)
+            gTasks[taskId].data[7] = 4;
+
+        //Set current value
+        switch (gTasks[taskId].data[7])
+        {
+        case 0:
+            sDebugMonData->mon_move_0 = gTasks[taskId].data[3];
+            break;
+        case 1:
+            sDebugMonData->mon_move_1 = gTasks[taskId].data[3];
+            break;
+        case 2:
+            sDebugMonData->mon_move_2 = gTasks[taskId].data[3];
+            break;
+        case 3:
+            sDebugMonData->mon_move_3 = gTasks[taskId].data[3];
+            break;
+        }
+
+        //If NOT last move or selected MOVE_NONE ask for next move, else make mon
+        if (gTasks[taskId].data[7] < 3)
+        {
+            gTasks[taskId].data[7] += 1;
+            gTasks[taskId].data[3] = 0;
+            gTasks[taskId].data[4] = 0;
+
+            StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+            StringCopy(gStringVar1, gMoveNames[gTasks[taskId].data[3]]);
+            StringCopyPadded(gStringVar1, gStringVar1, CHAR_SPACE, 15);
+            ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, 3);
+            switch (gTasks[taskId].data[7])
+            {
+            case 0:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_0);
+                break;
+            case 1:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_1);
+                break;
+            case 2:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_2);
+                break;
+            case 3:
+                StringExpandPlaceholders(gStringVar4, sDebugText_PokemonMove_3);
+                break;
+            }
+            AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+
+            gTasks[taskId].func = DebugAction_Give_Pokemon_Move;
+        }
+        else
+        {
+            gTasks[taskId].data[3] = 0;
+            gTasks[taskId].data[4] = 0;
+
+            PlaySE(MUS_LEVEL_UP);
+            gTasks[taskId].func = DebugAction_Give_Pokemon_ComplexCreateMon;
+        }
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        Free(sDebugMonData); //Frees EWRAM of MonData Struct
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+static void DebugAction_Give_Pokemon_ComplexCreateMon(u8 taskId) //https://github.com/ghoulslash/pokeemerald/tree/custom-givemon
+{
+    u16 nationalDexNum;
+    int sentToPc;
+    struct Pokemon mon;
+    u8 i;
+    u16 moves[4];
+    u8 IVs[6];
+    u8 iv_val;
+    u16 species     = sDebugMonData->mon_speciesId;
+    u8 level        = sDebugMonData->mon_level;
+    u8 isShiny      = sDebugMonData->isShiny; //Shiny: no 0, yes 1
+    u8 nature       = sDebugMonData->mon_natureId;
+    u8 abilityNum   = sDebugMonData->mon_abilityNum;
+    moves[0]        = sDebugMonData->mon_move_0;
+    moves[1]        = sDebugMonData->mon_move_1;
+    moves[2]        = sDebugMonData->mon_move_2;
+    moves[3]        = sDebugMonData->mon_move_3;
+    IVs[0]          = sDebugMonData->mon_iv_hp;
+    IVs[1]          = sDebugMonData->mon_iv_atk;
+    IVs[2]          = sDebugMonData->mon_iv_def;
+    IVs[3]          = sDebugMonData->mon_iv_speed;
+    IVs[4]          = sDebugMonData->mon_iv_satk;
+    IVs[5]          = sDebugMonData->mon_iv_sdef;
+
+
+    //Nature
+    if (nature == NUM_NATURES || nature == 0xFF)
+        nature = Random() % NUM_NATURES;
+
+    //Shinyness
+    if (isShiny == 1)
+    {
+        u32 personality;
+        u32 otid = gSaveBlock2Ptr->playerTrainerId[0]
+            | (gSaveBlock2Ptr->playerTrainerId[1] << 8)
+            | (gSaveBlock2Ptr->playerTrainerId[2] << 16)
+            | (gSaveBlock2Ptr->playerTrainerId[3] << 24);
+
+        do
+        {
+            personality = Random32();
+            personality = ((((Random() % 8) ^ (HIHALF(otid) ^ LOHALF(otid))) ^ LOHALF(personality)) << 16) | LOHALF(personality);
+        } while (nature != GetNatureFromPersonality(personality));
+
+        CreateMon(&mon, species, level, 32, 1, personality, OT_ID_PRESET, otid);
+    }
+    else
+        CreateMonWithNature(&mon, species, level, 32, nature);
+
+    //EVs/IVs
+    for (i = 0; i < NUM_STATS; i++)
+    {
+        // ev
+        // if (evs[i] != 0xFF && evTotal < 510)
+        // {
+        //     // only up to 510 evs
+        //     if ((evTotal + evs[i]) > 510)
+        //         evs[i] = (510 - evTotal);
+
+        //     evTotal += evs[i];
+        //     SetMonData(&mon, MON_DATA_HP_EV + i, &evs[i]);
+        // }
+
+        // iv
+        iv_val = IVs[i];
+        if (iv_val != 32 && iv_val != 0xFF)
+            SetMonData(&mon, MON_DATA_HP_IV + i, &iv_val);
+    }
+    CalculateMonStats(&mon);
+
+    //Moves
+    for (i = 0; i < MAX_MON_MOVES; i++)
+    {
+        if (moves[i] == 0 || moves[i] == 0xFF || moves[i] >= MOVES_COUNT)
+            continue;
+
+        SetMonMoveSlot(&mon, moves[i], i);
+    }
+
+    //Ability
+    if (abilityNum == 0xFF || GetAbilityBySpecies(species, abilityNum) == 0)
+    {
+        do {
+            abilityNum = Random() % 3;  // includes hidden abilities
+        } while (GetAbilityBySpecies(species, abilityNum) == 0);
+    }
+
+    SetMonData(&mon, MON_DATA_ABILITY_NUM, &abilityNum);
+
+    //ball
+    // if (ball <= POKEBALL_COUNT)
+    //     SetMonData(&mon, MON_DATA_POKEBALL, &ball);
+
+    //item
+    // heldItem[0] = item;
+    // heldItem[1] = item >> 8;
+    // SetMonData(&mon, MON_DATA_HELD_ITEM, heldItem);
+
+    // give player the mon
+    //sentToPc = GiveMonToPlayer(&mon);
+    SetMonData(&mon, MON_DATA_OT_NAME, gSaveBlock2Ptr->playerName);
+    SetMonData(&mon, MON_DATA_OT_GENDER, &gSaveBlock2Ptr->playerGender);
+    for (i = 0; i < PARTY_SIZE; i++)
+    {
+        if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, NULL) == SPECIES_NONE)
+            break;
+    }
+
+    if (i >= PARTY_SIZE)
+        sentToPc = CopyMonToPC(&mon);
+    else
+    {
+        sentToPc = MON_GIVEN_TO_PARTY;
+        CopyMon(&gPlayerParty[i], &mon, sizeof(mon));
+        gPlayerPartyCount = i + 1;
+    }
+
+    //Pokedex entry
+    nationalDexNum = SpeciesToNationalPokedexNum(species); 
+    switch(sentToPc)
+    {
+    case MON_GIVEN_TO_PARTY:
+    case MON_GIVEN_TO_PC:
+        GetSetPokedexFlag(nationalDexNum, FLAG_SET_SEEN);
+        GetSetPokedexFlag(nationalDexNum, FLAG_SET_CAUGHT);
+        break;
+    case MON_CANT_GIVE:
+        break;
+    }
+
+    Free(sDebugMonData); //Frees EWRAM of MonData Struct
+    DebugAction_DestroyExtraWindow(taskId); //return sentToPc;
+}
+
+static void DebugAction_Give_MaxMoney(u8 taskId)
+{
+    SetMoney(&gSaveBlock1Ptr->money, 999999);
+}
+
+static void DebugAction_Give_MaxCoins(u8 taskId)
+{
+    SetCoins(9999);
+}
+
+static void DebugAction_Give_MaxBattlePoints(u8 taskId)
+{
+    gSaveBlock2Ptr->frontier.battlePoints = MAX_BATTLE_FRONTIER_POINTS;
+}
+
+static void DebugAction_Give_DayCareEgg(u8 taskId)
+{
+    TriggerPendingDaycareEgg();
+}
+
+// *******************************
+// Actions Pokemon Creator
+static void DebugAction_PkmCreator_Party_Add(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(0, 0xFF);
+}
+static void DebugAction_PkmCreator_Party_Edit(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(1, 0xFF);
+}
+static void DebugAction_PkmCreator_PC_Edit(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(2, 0xFF);
+}
+static void DebugAction_PkmCreator_Enemy_Party_Edit(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(3, 0xFF);
+}
+static void DebugAction_PkmCreator_Enemy_Party_Edit_Debug(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(4, 0xFF);
+}
+static void DebugAction_PkmCreator_Debug_Edit(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(5, 0xFF);
+}
+static void DebugAction_PkmCreator_Enemy_Party_Add(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(6, 0xFF);
+}
+static void DebugAction_PkmCreator_Testing(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(7, 0xFF);
+}
+static void DebugAction_PkmCreator_Testing_Copy(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    LockPlayerFieldControls();
+    DebugPkmCreator_Init(8, 0xFF);
+}
+
+// *******************************
+// Actions Fill
+static void DebugAction_Fill_PCBoxes_Fast(u8 taskId) //Credit: Sierraffinity
+{
+    int boxId, boxPosition;
+    u32 personality;
+    struct BoxPokemon boxMon;
+
+    personality = Random32();
+
+    CreateBoxMon(&boxMon,
+                 SPECIES_BULBASAUR,
+                 100,
+                 32,
+                 personality,
+                 0,
+                 OT_ID_PLAYER_ID,
+                 0);
+
+    for (boxId = 0; boxId < TOTAL_BOXES_COUNT; boxId++)
+    {
+        for (boxPosition = 0; boxPosition < IN_BOX_COUNT; boxPosition++)
+        {
+            if (!GetBoxMonData(&gPokemonStoragePtr->boxes[boxId][boxPosition], MON_DATA_SANITY_HAS_SPECIES))
+            {
+                gPokemonStoragePtr->boxes[boxId][boxPosition] = boxMon;
+            }
+        }
+    }
+
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_Fill_PCBoxes_Slow(u8 taskId)
+{
+    int boxId, boxPosition;
+    u32 personality;
+    struct BoxPokemon boxMon;
+    u32 i = 1;
+
+    personality = Random32();
+
+    for (boxId = 0; boxId < TOTAL_BOXES_COUNT; boxId++)
+    {
+        for (boxPosition = 0; boxPosition < IN_BOX_COUNT; boxPosition++)
+        {
+            if (!GetBoxMonData(&gPokemonStoragePtr->boxes[boxId][boxPosition], MON_DATA_SANITY_HAS_SPECIES))
+            {
+                CreateBoxMon(&boxMon,
+                    i,
+                    100,
+                    32,
+                    personality,
+                    0,
+                    OT_ID_PLAYER_ID,
+                    0);
+
+            #ifndef POKEMON_EXPANSION
+                if (i < SPECIES_CELEBI)
+                    i += 1;
+                else if (i == SPECIES_CELEBI)
+                    i = SPECIES_TREECKO;
+                else if (i < SPECIES_CHIMECHO)
+                    i += 1;
+                else
+                    i = 1;
+            #else
+                if (i < FORMS_START - 1)
+                    i += 1;
+                else
+                    i = 1;
+            #endif
+
+                gPokemonStoragePtr->boxes[boxId][boxPosition] = boxMon;
+            }
+        }
+    }
+
+    Debug_DestroyMenu_Full(taskId);
+    ScriptContext_Enable();
+}
+static void DebugAction_Fill_PCItemStorage(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = 1; itemId < ITEMS_COUNT; itemId++)
+    {
+        if (!CheckPCHasItem(itemId, MAX_PC_ITEM_CAPACITY))
+            AddPCItem(itemId, MAX_PC_ITEM_CAPACITY);
+    }
+}
+static void DebugAction_Fill_PocketItems(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = 1; itemId < ITEMS_COUNT; itemId++)
+    {
+        if (ItemId_GetPocket(itemId) == POCKET_ITEMS && CheckBagHasSpace(itemId, MAX_BAG_ITEM_CAPACITY))
+            AddBagItem(itemId, MAX_BAG_ITEM_CAPACITY);
+    }
+}
+static void DebugAction_Fill_PocketPokeBalls(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = FIRST_BALL; itemId < LAST_BALL; itemId++)
+    {
+        if (CheckBagHasSpace(itemId, MAX_BAG_ITEM_CAPACITY))
+            AddBagItem(itemId, MAX_BAG_ITEM_CAPACITY);
+    }
+}
+static void DebugAction_Fill_PocketTMHM(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = ITEM_TM01; itemId <= ITEM_HM08; itemId++)
+    {
+        if (CheckBagHasSpace(itemId, 1) && ItemIdToBattleMoveId(itemId) != MOVE_NONE)
+            AddBagItem(itemId, 1);
+    }
+}
+static void DebugAction_Fill_PocketBerries(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = FIRST_BERRY_INDEX; itemId < LAST_BERRY_INDEX; itemId++)
+    {
+        if (CheckBagHasSpace(itemId, MAX_BERRY_CAPACITY))
+            AddBagItem(itemId, MAX_BERRY_CAPACITY);
+    }
+}
+static void DebugAction_Fill_PocketKeyItems(u8 taskId)
+{
+    u16 itemId;
+
+    for (itemId = 1; itemId < ITEMS_COUNT; itemId++)
+    {
+        if (ItemId_GetPocket(itemId) == POCKET_KEY_ITEMS && CheckBagHasSpace(itemId, 1))
+            AddBagItem(itemId, 1);
+    }
+}
+
+// *******************************
+// Actions Sound
+static const u8 *const gBGMNames[];
+static const u8 *const gSENames[];
+static void DebugAction_Sound_SE(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateSound);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, 1, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+    StringCopyPadded(gStringVar1, gSENames[0], CHAR_SPACE, 35);
+    StringExpandPlaceholders(gStringVar4, sDebugText_Sound_SE_ID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    StopMapMusic(); //Stop map music to better hear sounds
+
+    gTasks[taskId].func = DebugAction_Sound_SE_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = 1;                         //Current ID
+    gTasks[taskId].data[4] = 0;                         //Digit Selected
+    gTasks[taskId].data[5] = gTasks[taskId].data[3];    //Last song played (for stopping)
+}
+static void DebugAction_Sound_SE_SelectId(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > END_SE)
+                gTasks[taskId].data[3] = END_SE;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < 1)
+                gTasks[taskId].data[3] = 1;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < DEBUG_NUMBER_DIGITS_ITEMS-1)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringCopyPadded(gStringVar1, gSENames[gTasks[taskId].data[3]-1], CHAR_SPACE, 35);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Sound_SE_ID);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        m4aSongNumStop(gTasks[taskId].data[5]);
+        gTasks[taskId].data[5] = gTasks[taskId].data[3];
+        m4aSongNumStart(gTasks[taskId].data[3]);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        m4aSongNumStop(gTasks[taskId].data[5]);
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+
+static void DebugAction_Sound_MUS(u8 taskId)
+{
+    u8 windowId;
+
+    ClearStdWindowAndFrame(gTasks[taskId].data[1], TRUE);
+    RemoveWindow(gTasks[taskId].data[1]);
+
+    HideMapNamePopUpWindow();
+    LoadMessageBoxAndBorderGfx();
+    windowId = AddWindow(&sDebugMenuWindowTemplateSound);
+    DrawStdWindowFrame(windowId, FALSE);
+
+    CopyWindowToVram(windowId, 3);
+
+    //Display initial ID
+    StringCopy(gStringVar2, gText_DigitIndicator[0]);
+    ConvertIntToDecimalStringN(gStringVar3, START_MUS, STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+    StringCopyPadded(gStringVar1, gBGMNames[0], CHAR_SPACE, 35);
+    StringExpandPlaceholders(gStringVar4, sDebugText_Sound_MUS_ID);
+    AddTextPrinterParameterized(windowId, 1, gStringVar4, 1, 1, 0, NULL);
+
+    StopMapMusic(); //Stop map music to better hear new music
+
+    gTasks[taskId].func = DebugAction_Sound_MUS_SelectId;
+    gTasks[taskId].data[2] = windowId;
+    gTasks[taskId].data[3] = START_MUS;                 //Current ID
+    gTasks[taskId].data[4] = 0;                         //Digit Selected
+    gTasks[taskId].data[5] = gTasks[taskId].data[3];    //Last song played (for stopping)
+}
+static void DebugAction_Sound_MUS_SelectId(u8 taskId)
+{
+    if (gMain.newKeys & DPAD_ANY)
+    {
+        if (gMain.newKeys & DPAD_UP)
+        {
+            gTasks[taskId].data[3] += sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] > END_MUS)
+                gTasks[taskId].data[3] = END_MUS;
+        }
+        if (gMain.newKeys & DPAD_DOWN)
+        {
+            gTasks[taskId].data[3] -= sPowersOfTen[gTasks[taskId].data[4]];
+            if (gTasks[taskId].data[3] < START_MUS)
+                gTasks[taskId].data[3] = START_MUS;
+        }
+        if (gMain.newKeys & DPAD_LEFT)
+        {
+            if (gTasks[taskId].data[4] > 0)
+                gTasks[taskId].data[4] -= 1;
+        }
+        if (gMain.newKeys & DPAD_RIGHT)
+        {
+            if (gTasks[taskId].data[4] < DEBUG_NUMBER_DIGITS_ITEMS-1)
+                gTasks[taskId].data[4] += 1;
+        }
+
+        StringCopy(gStringVar2, gText_DigitIndicator[gTasks[taskId].data[4]]);
+        StringCopyPadded(gStringVar1, gBGMNames[gTasks[taskId].data[3]-START_MUS], CHAR_SPACE, 35);
+        ConvertIntToDecimalStringN(gStringVar3, gTasks[taskId].data[3], STR_CONV_MODE_LEADING_ZEROS, DEBUG_NUMBER_DIGITS_ITEMS);
+        StringExpandPlaceholders(gStringVar4, sDebugText_Sound_MUS_ID);
+        AddTextPrinterParameterized(gTasks[taskId].data[2], 1, gStringVar4, 1, 1, 0, NULL);
+    }
+
+    if (gMain.newKeys & A_BUTTON)
+    {
+        m4aSongNumStop(gTasks[taskId].data[5]);
+        gTasks[taskId].data[5] = gTasks[taskId].data[3];
+        m4aSongNumStart(gTasks[taskId].data[3]);
+    }
+    else if (gMain.newKeys & B_BUTTON)
+    {
+        PlaySE(SE_SELECT);
+        // m4aSongNumStop(gTasks[taskId].data[5]);   //Uncomment if music should stop after leaving menu
+        DebugAction_DestroyExtraWindow(taskId);
+    }
+}
+
+#define SOUND_LIST_BGM \
+    X(MUS_LITTLEROOT_TEST, "MUS-LITTLEROOT-TEST") \
+    X(MUS_GSC_ROUTE38, "MUS-GSC-ROUTE38") \
+    X(MUS_CAUGHT, "MUS-CAUGHT") \
+    X(MUS_VICTORY_WILD, "MUS-VICTORY-WILD") \
+    X(MUS_VICTORY_GYM_LEADER, "MUS-VICTORY-GYM-LEADER") \
+    X(MUS_VICTORY_LEAGUE, "MUS-VICTORY-LEAGUE") \
+    X(MUS_C_COMM_CENTER, "MUS-C-COMM-CENTER") \
+    X(MUS_GSC_PEWTER, "MUS-GSC-PEWTER") \
+    X(MUS_C_VS_LEGEND_BEAST, "MUS-C-VS-LEGEND-BEAST") \
+    X(MUS_ROUTE101, "MUS-ROUTE101") \
+    X(MUS_ROUTE110, "MUS-ROUTE110") \
+    X(MUS_ROUTE120, "MUS-ROUTE120") \
+    X(MUS_PETALBURG, "MUS-PETALBURG") \
+    X(MUS_OLDALE, "MUS-OLDALE") \
+    X(MUS_GYM, "MUS-GYM") \
+    X(MUS_SURF, "MUS-SURF") \
+    X(MUS_PETALBURG_WOODS, "MUS-PETALBURG-WOODS") \
+    X(MUS_LEVEL_UP, "MUS-LEVEL-UP") \
+    X(MUS_HEAL, "MUS-HEAL") \
+    X(MUS_OBTAIN_BADGE, "MUS-OBTAIN-BADGE") \
+    X(MUS_OBTAIN_ITEM, "MUS-OBTAIN-ITEM") \
+    X(MUS_EVOLVED, "MUS-EVOLVED") \
+    X(MUS_OBTAIN_TMHM, "MUS-OBTAIN-TMHM") \
+    X(MUS_LILYCOVE_MUSEUM, "MUS-LILYCOVE-MUSEUM") \
+    X(MUS_ROUTE122, "MUS-ROUTE122") \
+    X(MUS_OCEANIC_MUSEUM, "MUS-OCEANIC-MUSEUM") \
+    X(MUS_EVOLUTION_INTRO, "MUS-EVOLUTION-INTRO") \
+    X(MUS_EVOLUTION, "MUS-EVOLUTION") \
+    X(MUS_MOVE_DELETED, "MUS-MOVE-DELETED") \
+    X(MUS_ENCOUNTER_GIRL, "MUS-ENCOUNTER-GIRL") \
+    X(MUS_ENCOUNTER_MALE, "MUS-ENCOUNTER-MALE") \
+    X(MUS_ABANDONED_SHIP, "MUS-ABANDONED-SHIP") \
+    X(MUS_FORTREE, "MUS-FORTREE") \
+    X(MUS_BIRCH_LAB, "MUS-BIRCH-LAB") \
+    X(MUS_B_TOWER_RS, "MUS-B-TOWER-RS") \
+    X(MUS_ENCOUNTER_SWIMMER, "MUS-ENCOUNTER-SWIMMER") \
+    X(MUS_CAVE_OF_ORIGIN, "MUS-CAVE-OF-ORIGIN") \
+    X(MUS_OBTAIN_BERRY, "MUS-OBTAIN-BERRY") \
+    X(MUS_AWAKEN_LEGEND, "MUS-AWAKEN-LEGEND") \
+    X(MUS_SLOTS_JACKPOT, "MUS-SLOTS-JACKPOT") \
+    X(MUS_SLOTS_WIN, "MUS-SLOTS-WIN") \
+    X(MUS_TOO_BAD, "MUS-TOO-BAD") \
+    X(MUS_ROULETTE, "MUS-ROULETTE") \
+    X(MUS_LINK_CONTEST_P1, "MUS-LINK-CONTEST-P1") \
+    X(MUS_LINK_CONTEST_P2, "MUS-LINK-CONTEST-P2") \
+    X(MUS_LINK_CONTEST_P3, "MUS-LINK-CONTEST-P3") \
+    X(MUS_LINK_CONTEST_P4, "MUS-LINK-CONTEST-P4") \
+    X(MUS_ENCOUNTER_RICH, "MUS-ENCOUNTER-RICH") \
+    X(MUS_VERDANTURF, "MUS-VERDANTURF") \
+    X(MUS_RUSTBORO, "MUS-RUSTBORO") \
+    X(MUS_POKE_CENTER, "MUS-POKE-CENTER") \
+    X(MUS_ROUTE104, "MUS-ROUTE104") \
+    X(MUS_ROUTE119, "MUS-ROUTE119") \
+    X(MUS_CYCLING, "MUS-CYCLING") \
+    X(MUS_POKE_MART, "MUS-POKE-MART") \
+    X(MUS_LITTLEROOT, "MUS-LITTLEROOT") \
+    X(MUS_MT_CHIMNEY, "MUS-MT-CHIMNEY") \
+    X(MUS_ENCOUNTER_FEMALE, "MUS-ENCOUNTER-FEMALE") \
+    X(MUS_LILYCOVE, "MUS-LILYCOVE") \
+    X(MUS_ROUTE111, "MUS-ROUTE111") \
+    X(MUS_HELP, "MUS-HELP") \
+    X(MUS_UNDERWATER, "MUS-UNDERWATER") \
+    X(MUS_VICTORY_TRAINER, "MUS-VICTORY-TRAINER") \
+    X(MUS_TITLE, "MUS-TITLE") \
+    X(MUS_INTRO, "MUS-INTRO") \
+    X(MUS_ENCOUNTER_MAY, "MUS-ENCOUNTER-MAY") \
+    X(MUS_ENCOUNTER_INTENSE, "MUS-ENCOUNTER-INTENSE") \
+    X(MUS_ENCOUNTER_COOL, "MUS-ENCOUNTER-COOL") \
+    X(MUS_ROUTE113, "MUS-ROUTE113") \
+    X(MUS_ENCOUNTER_AQUA, "MUS-ENCOUNTER-AQUA") \
+    X(MUS_FOLLOW_ME, "MUS-FOLLOW-ME") \
+    X(MUS_ENCOUNTER_BRENDAN, "MUS-ENCOUNTER-BRENDAN") \
+    X(MUS_EVER_GRANDE, "MUS-EVER-GRANDE") \
+    X(MUS_ENCOUNTER_SUSPICIOUS, "MUS-ENCOUNTER-SUSPICIOUS") \
+    X(MUS_VICTORY_AQUA_MAGMA, "MUS-VICTORY-AQUA-MAGMA") \
+    X(MUS_CABLE_CAR, "MUS-CABLE-CAR") \
+    X(MUS_GAME_CORNER, "MUS-GAME-CORNER") \
+    X(MUS_DEWFORD, "MUS-DEWFORD") \
+    X(MUS_SAFARI_ZONE, "MUS-SAFARI-ZONE") \
+    X(MUS_VICTORY_ROAD, "MUS-VICTORY-ROAD") \
+    X(MUS_AQUA_MAGMA_HIDEOUT, "MUS-AQUA-MAGMA-HIDEOUT") \
+    X(MUS_SAILING, "MUS-SAILING") \
+    X(MUS_MT_PYRE, "MUS-MT-PYRE") \
+    X(MUS_SLATEPORT, "MUS-SLATEPORT") \
+    X(MUS_MT_PYRE_EXTERIOR, "MUS-MT-PYRE-EXTERIOR") \
+    X(MUS_SCHOOL, "MUS-SCHOOL") \
+    X(MUS_HALL_OF_FAME, "MUS-HALL-OF-FAME") \
+    X(MUS_FALLARBOR, "MUS-FALLARBOR") \
+    X(MUS_SEALED_CHAMBER, "MUS-SEALED-CHAMBER") \
+    X(MUS_CONTEST_WINNER, "MUS-CONTEST-WINNER") \
+    X(MUS_CONTEST, "MUS-CONTEST") \
+    X(MUS_ENCOUNTER_MAGMA, "MUS-ENCOUNTER-MAGMA") \
+    X(MUS_INTRO_BATTLE, "MUS-INTRO-BATTLE") \
+    X(MUS_WEATHER_KYOGRE, "MUS-WEATHER-KYOGRE") \
+    X(MUS_WEATHER_GROUDON, "MUS-WEATHER-GROUDON") \
+    X(MUS_SOOTOPOLIS, "MUS-SOOTOPOLIS") \
+    X(MUS_CONTEST_RESULTS, "MUS-CONTEST-RESULTS") \
+    X(MUS_HALL_OF_FAME_ROOM, "MUS-HALL-OF-FAME-ROOM") \
+    X(MUS_TRICK_HOUSE, "MUS-TRICK-HOUSE") \
+    X(MUS_ENCOUNTER_TWINS, "MUS-ENCOUNTER-TWINS") \
+    X(MUS_ENCOUNTER_ELITE_FOUR, "MUS-ENCOUNTER-ELITE-FOUR") \
+    X(MUS_ENCOUNTER_HIKER, "MUS-ENCOUNTER-HIKER") \
+    X(MUS_CONTEST_LOBBY, "MUS-CONTEST-LOBBY") \
+    X(MUS_ENCOUNTER_INTERVIEWER, "MUS-ENCOUNTER-INTERVIEWER") \
+    X(MUS_ENCOUNTER_CHAMPION, "MUS-ENCOUNTER-CHAMPION") \
+    X(MUS_CREDITS, "MUS-CREDITS") \
+    X(MUS_END, "MUS-END") \
+    X(MUS_B_FRONTIER, "MUS-B-FRONTIER") \
+    X(MUS_B_ARENA, "MUS-B-ARENA") \
+    X(MUS_OBTAIN_B_POINTS, "MUS-OBTAIN-B-POINTS") \
+    X(MUS_REGISTER_MATCH_CALL, "MUS-REGISTER-MATCH-CALL") \
+    X(MUS_B_PYRAMID, "MUS-B-PYRAMID") \
+    X(MUS_B_PYRAMID_TOP, "MUS-B-PYRAMID-TOP") \
+    X(MUS_B_PALACE, "MUS-B-PALACE") \
+    X(MUS_RAYQUAZA_APPEARS, "MUS-RAYQUAZA-APPEARS") \
+    X(MUS_B_TOWER, "MUS-B-TOWER") \
+    X(MUS_OBTAIN_SYMBOL, "MUS-OBTAIN-SYMBOL") \
+    X(MUS_B_DOME, "MUS-B-DOME") \
+    X(MUS_B_PIKE, "MUS-B-PIKE") \
+    X(MUS_B_FACTORY, "MUS-B-FACTORY") \
+    X(MUS_VS_RAYQUAZA, "MUS-VS-RAYQUAZA") \
+    X(MUS_VS_FRONTIER_BRAIN, "MUS-VS-FRONTIER-BRAIN") \
+    X(MUS_VS_MEW, "MUS-VS-MEW") \
+    X(MUS_B_DOME_LOBBY, "MUS-B-DOME-LOBBY") \
+    X(MUS_VS_WILD, "MUS-VS-WILD") \
+    X(MUS_VS_AQUA_MAGMA, "MUS-VS-AQUA-MAGMA") \
+    X(MUS_VS_TRAINER, "MUS-VS-TRAINER") \
+    X(MUS_VS_GYM_LEADER, "MUS-VS-GYM-LEADER") \
+    X(MUS_VS_CHAMPION, "MUS-VS-CHAMPION") \
+    X(MUS_VS_REGI, "MUS-VS-REGI") \
+    X(MUS_VS_KYOGRE_GROUDON, "MUS-VS-KYOGRE-GROUDON") \
+    X(MUS_VS_RIVAL, "MUS-VS-RIVAL") \
+    X(MUS_VS_ELITE_FOUR, "MUS-VS-ELITE-FOUR") \
+    X(MUS_VS_AQUA_MAGMA_LEADER, "MUS-VS-AQUA-MAGMA-LEADER") \
+    X(MUS_RG_FOLLOW_ME, "MUS-RG-FOLLOW-ME") \
+    X(MUS_RG_GAME_CORNER, "MUS-RG-GAME-CORNER") \
+    X(MUS_RG_ROCKET_HIDEOUT, "MUS-RG-ROCKET-HIDEOUT") \
+    X(MUS_RG_GYM, "MUS-RG-GYM") \
+    X(MUS_RG_JIGGLYPUFF, "MUS-RG-JIGGLYPUFF") \
+    X(MUS_RG_INTRO_FIGHT, "MUS-RG-INTRO-FIGHT") \
+    X(MUS_RG_TITLE, "MUS-RG-TITLE") \
+    X(MUS_RG_CINNABAR, "MUS-RG-CINNABAR") \
+    X(MUS_RG_LAVENDER, "MUS-RG-LAVENDER") \
+    X(MUS_RG_HEAL, "MUS-RG-HEAL") \
+    X(MUS_RG_CYCLING, "MUS-RG-CYCLING") \
+    X(MUS_RG_ENCOUNTER_ROCKET, "MUS-RG-ENCOUNTER-ROCKET") \
+    X(MUS_RG_ENCOUNTER_GIRL, "MUS-RG-ENCOUNTER-GIRL") \
+    X(MUS_RG_ENCOUNTER_BOY, "MUS-RG-ENCOUNTER-BOY") \
+    X(MUS_RG_HALL_OF_FAME, "MUS-RG-HALL-OF-FAME") \
+    X(MUS_RG_VIRIDIAN_FOREST, "MUS-RG-VIRIDIAN-FOREST") \
+    X(MUS_RG_MT_MOON, "MUS-RG-MT-MOON") \
+    X(MUS_RG_POKE_MANSION, "MUS-RG-POKE-MANSION") \
+    X(MUS_RG_CREDITS, "MUS-RG-CREDITS") \
+    X(MUS_RG_ROUTE1, "MUS-RG-ROUTE1") \
+    X(MUS_RG_ROUTE24, "MUS-RG-ROUTE24") \
+    X(MUS_RG_ROUTE3, "MUS-RG-ROUTE3") \
+    X(MUS_RG_ROUTE11, "MUS-RG-ROUTE11") \
+    X(MUS_RG_VICTORY_ROAD, "MUS-RG-VICTORY-ROAD") \
+    X(MUS_RG_VS_GYM_LEADER, "MUS-RG-VS-GYM-LEADER") \
+    X(MUS_RG_VS_TRAINER, "MUS-RG-VS-TRAINER") \
+    X(MUS_RG_VS_WILD, "MUS-RG-VS-WILD") \
+    X(MUS_RG_VS_CHAMPION, "MUS-RG-VS-CHAMPION") \
+    X(MUS_RG_PALLET, "MUS-RG-PALLET") \
+    X(MUS_RG_OAK_LAB, "MUS-RG-OAK-LAB") \
+    X(MUS_RG_OAK, "MUS-RG-OAK") \
+    X(MUS_RG_POKE_CENTER, "MUS-RG-POKE-CENTER") \
+    X(MUS_RG_SS_ANNE, "MUS-RG-SS-ANNE") \
+    X(MUS_RG_SURF, "MUS-RG-SURF") \
+    X(MUS_RG_POKE_TOWER, "MUS-RG-POKE-TOWER") \
+    X(MUS_RG_SILPH, "MUS-RG-SILPH") \
+    X(MUS_RG_FUCHSIA, "MUS-RG-FUCHSIA") \
+    X(MUS_RG_CELADON, "MUS-RG-CELADON") \
+    X(MUS_RG_VICTORY_TRAINER, "MUS-RG-VICTORY-TRAINER") \
+    X(MUS_RG_VICTORY_WILD, "MUS-RG-VICTORY-WILD") \
+    X(MUS_RG_VICTORY_GYM_LEADER, "MUS-RG-VICTORY-GYM-LEADER") \
+    X(MUS_RG_VERMILLION, "MUS-RG-VERMILLION") \
+    X(MUS_RG_PEWTER, "MUS-RG-PEWTER") \
+    X(MUS_RG_ENCOUNTER_RIVAL, "MUS-RG-ENCOUNTER-RIVAL") \
+    X(MUS_RG_RIVAL_EXIT, "MUS-RG-RIVAL-EXIT") \
+    X(MUS_RG_DEX_RATING, "MUS-RG-DEX-RATING") \
+    X(MUS_RG_OBTAIN_KEY_ITEM, "MUS-RG-OBTAIN-KEY-ITEM") \
+    X(MUS_RG_CAUGHT_INTRO, "MUS-RG-CAUGHT-INTRO") \
+    X(MUS_RG_PHOTO, "MUS-RG-PHOTO") \
+    X(MUS_RG_GAME_FREAK, "MUS-RG-GAME-FREAK") \
+    X(MUS_RG_CAUGHT, "MUS-RG-CAUGHT") \
+    X(MUS_RG_NEW_GAME_INSTRUCT, "MUS-RG-NEW-GAME-INSTRUCT") \
+    X(MUS_RG_NEW_GAME_INTRO, "MUS-RG-NEW-GAME-INTRO") \
+    X(MUS_RG_NEW_GAME_EXIT, "MUS-RG-NEW-GAME-EXIT") \
+    X(MUS_RG_POKE_JUMP, "MUS-RG-POKE-JUMP") \
+    X(MUS_RG_UNION_ROOM, "MUS-RG-UNION-ROOM") \
+    X(MUS_RG_NET_CENTER, "MUS-RG-NET-CENTER") \
+    X(MUS_RG_MYSTERY_GIFT, "MUS-RG-MYSTERY-GIFT") \
+    X(MUS_RG_BERRY_PICK, "MUS-RG-BERRY-PICK") \
+    X(MUS_RG_SEVII_CAVE, "MUS-RG-SEVII-CAVE") \
+    X(MUS_RG_TEACHY_TV_SHOW, "MUS-RG-TEACHY-TV-SHOW") \
+    X(MUS_RG_SEVII_ROUTE, "MUS-RG-SEVII-ROUTE") \
+    X(MUS_RG_SEVII_DUNGEON, "MUS-RG-SEVII-DUNGEON") \
+    X(MUS_RG_SEVII_123, "MUS-RG-SEVII-123") \
+    X(MUS_RG_SEVII_45, "MUS-RG-SEVII-45") \
+    X(MUS_RG_SEVII_67, "MUS-RG-SEVII-67") \
+    X(MUS_RG_POKE_FLUTE, "MUS-RG-POKE-FLUTE") \
+    X(MUS_RG_VS_DEOXYS, "MUS-RG-VS-DEOXYS") \
+    X(MUS_RG_VS_MEWTWO, "MUS-RG-VS-MEWTWO") \
+    X(MUS_RG_VS_LEGEND, "MUS-RG-VS-LEGEND") \
+    X(MUS_RG_ENCOUNTER_GYM_LEADER, "MUS-RG-ENCOUNTER-GYM-LEADER") \
+    X(MUS_RG_ENCOUNTER_DEOXYS, "MUS-RG-ENCOUNTER-DEOXYS") \
+    X(MUS_RG_TRAINER_TOWER, "MUS-RG-TRAINER-TOWER") \
+    X(MUS_RG_SLOW_PALLET, "MUS-RG-SLOW-PALLET") \
+    X(MUS_RG_TEACHY_TV_MENU, "MUS-RG-TEACHY-TV-MENU") \
+    X(PH_TRAP_BLEND, "PH-TRAP-BLEND") \
+    X(PH_TRAP_HELD, "PH-TRAP-HELD") \
+    X(PH_TRAP_SOLO, "PH-TRAP-SOLO") \
+    X(PH_FACE_BLEND, "PH-FACE-BLEND") \
+    X(PH_FACE_HELD, "PH-FACE-HELD") \
+    X(PH_FACE_SOLO, "PH-FACE-SOLO") \
+    X(PH_CLOTH_BLEND, "PH-CLOTH-BLEND") \
+    X(PH_CLOTH_HELD, "PH-CLOTH-HELD") \
+    X(PH_CLOTH_SOLO, "PH-CLOTH-SOLO") \
+    X(PH_DRESS_BLEND, "PH-DRESS-BLEND") \
+    X(PH_DRESS_HELD, "PH-DRESS-HELD") \
+    X(PH_DRESS_SOLO, "PH-DRESS-SOLO") \
+    X(PH_FLEECE_BLEND, "PH-FLEECE-BLEND") \
+    X(PH_FLEECE_HELD, "PH-FLEECE-HELD") \
+    X(PH_FLEECE_SOLO, "PH-FLEECE-SOLO") \
+    X(PH_KIT_BLEND, "PH-KIT-BLEND") \
+    X(PH_KIT_HELD, "PH-KIT-HELD") \
+    X(PH_KIT_SOLO, "PH-KIT-SOLO") \
+    X(PH_PRICE_BLEND, "PH-PRICE-BLEND") \
+    X(PH_PRICE_HELD, "PH-PRICE-HELD") \
+    X(PH_PRICE_SOLO, "PH-PRICE-SOLO") \
+    X(PH_LOT_BLEND, "PH-LOT-BLEND") \
+    X(PH_LOT_HELD, "PH-LOT-HELD") \
+    X(PH_LOT_SOLO, "PH-LOT-SOLO") \
+    X(PH_GOAT_BLEND, "PH-GOAT-BLEND") \
+    X(PH_GOAT_HELD, "PH-GOAT-HELD") \
+    X(PH_GOAT_SOLO, "PH-GOAT-SOLO") \
+    X(PH_THOUGHT_BLEND, "PH-THOUGHT-BLEND") \
+    X(PH_THOUGHT_HELD, "PH-THOUGHT-HELD") \
+    X(PH_THOUGHT_SOLO, "PH-THOUGHT-SOLO") \
+    X(PH_CHOICE_BLEND, "PH-CHOICE-BLEND") \
+    X(PH_CHOICE_HELD, "PH-CHOICE-HELD") \
+    X(PH_CHOICE_SOLO, "PH-CHOICE-SOLO") \
+    X(PH_MOUTH_BLEND, "PH-MOUTH-BLEND") \
+    X(PH_MOUTH_HELD, "PH-MOUTH-HELD") \
+    X(PH_MOUTH_SOLO, "PH-MOUTH-SOLO") \
+    X(PH_FOOT_BLEND, "PH-FOOT-BLEND") \
+    X(PH_FOOT_HELD, "PH-FOOT-HELD") \
+    X(PH_FOOT_SOLO, "PH-FOOT-SOLO") \
+    X(PH_GOOSE_BLEND, "PH-GOOSE-BLEND") \
+    X(PH_GOOSE_HELD, "PH-GOOSE-HELD") \
+    X(PH_GOOSE_SOLO, "PH-GOOSE-SOLO") \
+    X(PH_STRUT_BLEND, "PH-STRUT-BLEND") \
+    X(PH_STRUT_HELD, "PH-STRUT-HELD") \
+    X(PH_STRUT_SOLO, "PH-STRUT-SOLO") \
+    X(PH_CURE_BLEND, "PH-CURE-BLEND") \
+    X(PH_CURE_HELD, "PH-CURE-HELD") \
+    X(PH_CURE_SOLO, "PH-CURE-SOLO") \
+    X(PH_NURSE_BLEND, "PH-NURSE-BLEND") \
+    X(PH_NURSE_HELD, "PH-NURSE-HELD") \
+    X(PH_NURSE_SOLO, "PH-NURSE-SOLO") \
+
+#define SOUND_LIST_SE \
+    X(SE_USE_ITEM, "SE-USE-ITEM") \
+    X(SE_PC_LOGIN, "SE-PC-LOGIN") \
+    X(SE_PC_OFF, "SE-PC-OFF") \
+    X(SE_PC_ON, "SE-PC-ON") \
+    X(SE_SELECT, "SE-SELECT") \
+    X(SE_WIN_OPEN, "SE-WIN-OPEN") \
+    X(SE_WALL_HIT, "SE-WALL-HIT") \
+    X(SE_DOOR, "SE-DOOR") \
+    X(SE_EXIT, "SE-EXIT") \
+    X(SE_LEDGE, "SE-LEDGE") \
+    X(SE_BIKE_BELL, "SE-BIKE-BELL") \
+    X(SE_NOT_EFFECTIVE, "SE-NOT-EFFECTIVE") \
+    X(SE_EFFECTIVE, "SE-EFFECTIVE") \
+    X(SE_SUPER_EFFECTIVE, "SE-SUPER-EFFECTIVE") \
+    X(SE_BALL_OPEN, "SE-BALL-OPEN") \
+    X(SE_FAINT, "SE-FAINT") \
+    X(SE_FLEE, "SE-FLEE") \
+    X(SE_SLIDING_DOOR, "SE-SLIDING-DOOR") \
+    X(SE_SHIP, "SE-SHIP") \
+    X(SE_BANG, "SE-BANG") \
+    X(SE_PIN, "SE-PIN") \
+    X(SE_BOO, "SE-BOO") \
+    X(SE_BALL, "SE-BALL") \
+    X(SE_CONTEST_PLACE, "SE-CONTEST-PLACE") \
+    X(SE_A, "SE-A") \
+    X(SE_I, "SE-I") \
+    X(SE_U, "SE-U") \
+    X(SE_E, "SE-E") \
+    X(SE_O, "SE-O") \
+    X(SE_N, "SE-N") \
+    X(SE_SUCCESS, "SE-SUCCESS") \
+    X(SE_FAILURE, "SE-FAILURE") \
+    X(SE_EXP, "SE-EXP") \
+    X(SE_BIKE_HOP, "SE-BIKE-HOP") \
+    X(SE_SWITCH, "SE-SWITCH") \
+    X(SE_CLICK, "SE-CLICK") \
+    X(SE_FU_ZAKU, "SE-FU-ZAKU") \
+    X(SE_CONTEST_CONDITION_LOSE, "SE-CONTEST-CONDITION-LOSE") \
+    X(SE_LAVARIDGE_FALL_WARP, "SE-LAVARIDGE-FALL-WARP") \
+    X(SE_ICE_STAIRS, "SE-ICE-STAIRS") \
+    X(SE_ICE_BREAK, "SE-ICE-BREAK") \
+    X(SE_ICE_CRACK, "SE-ICE-CRACK") \
+    X(SE_FALL, "SE-FALL") \
+    X(SE_UNLOCK, "SE-UNLOCK") \
+    X(SE_WARP_IN, "SE-WARP-IN") \
+    X(SE_WARP_OUT, "SE-WARP-OUT") \
+    X(SE_REPEL, "SE-REPEL") \
+    X(SE_ROTATING_GATE, "SE-ROTATING-GATE") \
+    X(SE_TRUCK_MOVE, "SE-TRUCK-MOVE") \
+    X(SE_TRUCK_STOP, "SE-TRUCK-STOP") \
+    X(SE_TRUCK_UNLOAD, "SE-TRUCK-UNLOAD") \
+    X(SE_TRUCK_DOOR, "SE-TRUCK-DOOR") \
+    X(SE_BERRY_BLENDER, "SE-BERRY-BLENDER") \
+    X(SE_CARD, "SE-CARD") \
+    X(SE_SAVE, "SE-SAVE") \
+    X(SE_BALL_BOUNCE_1, "SE-BALL-BOUNCE-1") \
+    X(SE_BALL_BOUNCE_2, "SE-BALL-BOUNCE-2") \
+    X(SE_BALL_BOUNCE_3, "SE-BALL-BOUNCE-3") \
+    X(SE_BALL_BOUNCE_4, "SE-BALL-BOUNCE-4") \
+    X(SE_BALL_TRADE, "SE-BALL-TRADE") \
+    X(SE_BALL_THROW, "SE-BALL-THROW") \
+    X(SE_NOTE_C, "SE-NOTE-C") \
+    X(SE_NOTE_D, "SE-NOTE-D") \
+    X(SE_NOTE_E, "SE-NOTE-E") \
+    X(SE_NOTE_F, "SE-NOTE-F") \
+    X(SE_NOTE_G, "SE-NOTE-G") \
+    X(SE_NOTE_A, "SE-NOTE-A") \
+    X(SE_NOTE_B, "SE-NOTE-B") \
+    X(SE_NOTE_C_HIGH, "SE-NOTE-C-HIGH") \
+    X(SE_PUDDLE, "SE-PUDDLE") \
+    X(SE_BRIDGE_WALK, "SE-BRIDGE-WALK") \
+    X(SE_ITEMFINDER, "SE-ITEMFINDER") \
+    X(SE_DING_DONG, "SE-DING-DONG") \
+    X(SE_BALLOON_RED, "SE-BALLOON-RED") \
+    X(SE_BALLOON_BLUE, "SE-BALLOON-BLUE") \
+    X(SE_BALLOON_YELLOW, "SE-BALLOON-YELLOW") \
+    X(SE_BREAKABLE_DOOR, "SE-BREAKABLE-DOOR") \
+    X(SE_MUD_BALL, "SE-MUD-BALL") \
+    X(SE_FIELD_POISON, "SE-FIELD-POISON") \
+    X(SE_ESCALATOR, "SE-ESCALATOR") \
+    X(SE_THUNDERSTORM, "SE-THUNDERSTORM") \
+    X(SE_THUNDERSTORM_STOP, "SE-THUNDERSTORM-STOP") \
+    X(SE_DOWNPOUR, "SE-DOWNPOUR") \
+    X(SE_DOWNPOUR_STOP, "SE-DOWNPOUR-STOP") \
+    X(SE_RAIN, "SE-RAIN") \
+    X(SE_RAIN_STOP, "SE-RAIN-STOP") \
+    X(SE_THUNDER, "SE-THUNDER") \
+    X(SE_THUNDER2, "SE-THUNDER2") \
+    X(SE_ELEVATOR, "SE-ELEVATOR") \
+    X(SE_LOW_HEALTH, "SE-LOW-HEALTH") \
+    X(SE_EXP_MAX, "SE-EXP-MAX") \
+    X(SE_ROULETTE_BALL, "SE-ROULETTE-BALL") \
+    X(SE_ROULETTE_BALL2, "SE-ROULETTE-BALL2") \
+    X(SE_TAILLOW_WING_FLAP, "SE-TAILLOW-WING-FLAP") \
+    X(SE_SHOP, "SE-SHOP") \
+    X(SE_CONTEST_HEART, "SE-CONTEST-HEART") \
+    X(SE_CONTEST_CURTAIN_RISE, "SE-CONTEST-CURTAIN-RISE") \
+    X(SE_CONTEST_CURTAIN_FALL, "SE-CONTEST-CURTAIN-FALL") \
+    X(SE_CONTEST_ICON_CHANGE, "SE-CONTEST-ICON-CHANGE") \
+    X(SE_CONTEST_ICON_CLEAR, "SE-CONTEST-ICON-CLEAR") \
+    X(SE_CONTEST_MONS_TURN, "SE-CONTEST-MONS-TURN") \
+    X(SE_SHINY, "SE-SHINY") \
+    X(SE_INTRO_BLAST, "SE-INTRO-BLAST") \
+    X(SE_MUGSHOT, "SE-MUGSHOT") \
+    X(SE_APPLAUSE, "SE-APPLAUSE") \
+    X(SE_VEND, "SE-VEND") \
+    X(SE_ORB, "SE-ORB") \
+    X(SE_DEX_SCROLL, "SE-DEX-SCROLL") \
+    X(SE_DEX_PAGE, "SE-DEX-PAGE") \
+    X(SE_POKENAV_ON, "SE-POKENAV-ON") \
+    X(SE_POKENAV_OFF, "SE-POKENAV-OFF") \
+    X(SE_DEX_SEARCH, "SE-DEX-SEARCH") \
+    X(SE_EGG_HATCH, "SE-EGG-HATCH") \
+    X(SE_BALL_TRAY_ENTER, "SE-BALL-TRAY-ENTER") \
+    X(SE_BALL_TRAY_BALL, "SE-BALL-TRAY-BALL") \
+    X(SE_BALL_TRAY_EXIT, "SE-BALL-TRAY-EXIT") \
+    X(SE_GLASS_FLUTE, "SE-GLASS-FLUTE") \
+    X(SE_M_THUNDERBOLT, "SE-M-THUNDERBOLT") \
+    X(SE_M_THUNDERBOLT2, "SE-M-THUNDERBOLT2") \
+    X(SE_M_HARDEN, "SE-M-HARDEN") \
+    X(SE_M_NIGHTMARE, "SE-M-NIGHTMARE") \
+    X(SE_M_VITAL_THROW, "SE-M-VITAL-THROW") \
+    X(SE_M_VITAL_THROW2, "SE-M-VITAL-THROW2") \
+    X(SE_M_BUBBLE, "SE-M-BUBBLE") \
+    X(SE_M_BUBBLE2, "SE-M-BUBBLE2") \
+    X(SE_M_BUBBLE3, "SE-M-BUBBLE3") \
+    X(SE_M_RAIN_DANCE, "SE-M-RAIN-DANCE") \
+    X(SE_M_CUT, "SE-M-CUT") \
+    X(SE_M_STRING_SHOT, "SE-M-STRING-SHOT") \
+    X(SE_M_STRING_SHOT2, "SE-M-STRING-SHOT2") \
+    X(SE_M_ROCK_THROW, "SE-M-ROCK-THROW") \
+    X(SE_M_GUST, "SE-M-GUST") \
+    X(SE_M_GUST2, "SE-M-GUST2") \
+    X(SE_M_DOUBLE_SLAP, "SE-M-DOUBLE-SLAP") \
+    X(SE_M_DOUBLE_TEAM, "SE-M-DOUBLE-TEAM") \
+    X(SE_M_RAZOR_WIND, "SE-M-RAZOR-WIND") \
+    X(SE_M_ICY_WIND, "SE-M-ICY-WIND") \
+    X(SE_M_THUNDER_WAVE, "SE-M-THUNDER-WAVE") \
+    X(SE_M_COMET_PUNCH, "SE-M-COMET-PUNCH") \
+    X(SE_M_MEGA_KICK, "SE-M-MEGA-KICK") \
+    X(SE_M_MEGA_KICK2, "SE-M-MEGA-KICK2") \
+    X(SE_M_CRABHAMMER, "SE-M-CRABHAMMER") \
+    X(SE_M_JUMP_KICK, "SE-M-JUMP-KICK") \
+    X(SE_M_FLAME_WHEEL, "SE-M-FLAME-WHEEL") \
+    X(SE_M_FLAME_WHEEL2, "SE-M-FLAME-WHEEL2") \
+    X(SE_M_FLAMETHROWER, "SE-M-FLAMETHROWER") \
+    X(SE_M_FIRE_PUNCH, "SE-M-FIRE-PUNCH") \
+    X(SE_M_TOXIC, "SE-M-TOXIC") \
+    X(SE_M_SACRED_FIRE, "SE-M-SACRED-FIRE") \
+    X(SE_M_SACRED_FIRE2, "SE-M-SACRED-FIRE2") \
+    X(SE_M_EMBER, "SE-M-EMBER") \
+    X(SE_M_TAKE_DOWN, "SE-M-TAKE-DOWN") \
+    X(SE_M_BLIZZARD, "SE-M-BLIZZARD") \
+    X(SE_M_BLIZZARD2, "SE-M-BLIZZARD2") \
+    X(SE_M_SCRATCH, "SE-M-SCRATCH") \
+    X(SE_M_VICEGRIP, "SE-M-VICEGRIP") \
+    X(SE_M_WING_ATTACK, "SE-M-WING-ATTACK") \
+    X(SE_M_FLY, "SE-M-FLY") \
+    X(SE_M_SAND_ATTACK, "SE-M-SAND-ATTACK") \
+    X(SE_M_RAZOR_WIND2, "SE-M-RAZOR-WIND2") \
+    X(SE_M_BITE, "SE-M-BITE") \
+    X(SE_M_HEADBUTT, "SE-M-HEADBUTT") \
+    X(SE_M_SURF, "SE-M-SURF") \
+    X(SE_M_HYDRO_PUMP, "SE-M-HYDRO-PUMP") \
+    X(SE_M_WHIRLPOOL, "SE-M-WHIRLPOOL") \
+    X(SE_M_HORN_ATTACK, "SE-M-HORN-ATTACK") \
+    X(SE_M_TAIL_WHIP, "SE-M-TAIL-WHIP") \
+    X(SE_M_MIST, "SE-M-MIST") \
+    X(SE_M_POISON_POWDER, "SE-M-POISON-POWDER") \
+    X(SE_M_BIND, "SE-M-BIND") \
+    X(SE_M_DRAGON_RAGE, "SE-M-DRAGON-RAGE") \
+    X(SE_M_SING, "SE-M-SING") \
+    X(SE_M_PERISH_SONG, "SE-M-PERISH-SONG") \
+    X(SE_M_PAY_DAY, "SE-M-PAY-DAY") \
+    X(SE_M_DIG, "SE-M-DIG") \
+    X(SE_M_DIZZY_PUNCH, "SE-M-DIZZY-PUNCH") \
+    X(SE_M_SELF_DESTRUCT, "SE-M-SELF-DESTRUCT") \
+    X(SE_M_EXPLOSION, "SE-M-EXPLOSION") \
+    X(SE_M_ABSORB_2, "SE-M-ABSORB-2") \
+    X(SE_M_ABSORB, "SE-M-ABSORB") \
+    X(SE_M_SCREECH, "SE-M-SCREECH") \
+    X(SE_M_BUBBLE_BEAM, "SE-M-BUBBLE-BEAM") \
+    X(SE_M_BUBBLE_BEAM2, "SE-M-BUBBLE-BEAM2") \
+    X(SE_M_SUPERSONIC, "SE-M-SUPERSONIC") \
+    X(SE_M_BELLY_DRUM, "SE-M-BELLY-DRUM") \
+    X(SE_M_METRONOME, "SE-M-METRONOME") \
+    X(SE_M_BONEMERANG, "SE-M-BONEMERANG") \
+    X(SE_M_LICK, "SE-M-LICK") \
+    X(SE_M_PSYBEAM, "SE-M-PSYBEAM") \
+    X(SE_M_FAINT_ATTACK, "SE-M-FAINT-ATTACK") \
+    X(SE_M_SWORDS_DANCE, "SE-M-SWORDS-DANCE") \
+    X(SE_M_LEER, "SE-M-LEER") \
+    X(SE_M_SWAGGER, "SE-M-SWAGGER") \
+    X(SE_M_SWAGGER2, "SE-M-SWAGGER2") \
+    X(SE_M_HEAL_BELL, "SE-M-HEAL-BELL") \
+    X(SE_M_CONFUSE_RAY, "SE-M-CONFUSE-RAY") \
+    X(SE_M_SNORE, "SE-M-SNORE") \
+    X(SE_M_BRICK_BREAK, "SE-M-BRICK-BREAK") \
+    X(SE_M_GIGA_DRAIN, "SE-M-GIGA-DRAIN") \
+    X(SE_M_PSYBEAM2, "SE-M-PSYBEAM2") \
+    X(SE_M_SOLAR_BEAM, "SE-M-SOLAR-BEAM") \
+    X(SE_M_PETAL_DANCE, "SE-M-PETAL-DANCE") \
+    X(SE_M_TELEPORT, "SE-M-TELEPORT") \
+    X(SE_M_MINIMIZE, "SE-M-MINIMIZE") \
+    X(SE_M_SKETCH, "SE-M-SKETCH") \
+    X(SE_M_SWIFT, "SE-M-SWIFT") \
+    X(SE_M_REFLECT, "SE-M-REFLECT") \
+    X(SE_M_BARRIER, "SE-M-BARRIER") \
+    X(SE_M_DETECT, "SE-M-DETECT") \
+    X(SE_M_LOCK_ON, "SE-M-LOCK-ON") \
+    X(SE_M_MOONLIGHT, "SE-M-MOONLIGHT") \
+    X(SE_M_CHARM, "SE-M-CHARM") \
+    X(SE_M_CHARGE, "SE-M-CHARGE") \
+    X(SE_M_STRENGTH, "SE-M-STRENGTH") \
+    X(SE_M_HYPER_BEAM, "SE-M-HYPER-BEAM") \
+    X(SE_M_WATERFALL, "SE-M-WATERFALL") \
+    X(SE_M_REVERSAL, "SE-M-REVERSAL") \
+    X(SE_M_ACID_ARMOR, "SE-M-ACID-ARMOR") \
+    X(SE_M_SANDSTORM, "SE-M-SANDSTORM") \
+    X(SE_M_TRI_ATTACK, "SE-M-TRI-ATTACK") \
+    X(SE_M_TRI_ATTACK2, "SE-M-TRI-ATTACK2") \
+    X(SE_M_ENCORE, "SE-M-ENCORE") \
+    X(SE_M_ENCORE2, "SE-M-ENCORE2") \
+    X(SE_M_BATON_PASS, "SE-M-BATON-PASS") \
+    X(SE_M_MILK_DRINK, "SE-M-MILK-DRINK") \
+    X(SE_M_ATTRACT, "SE-M-ATTRACT") \
+    X(SE_M_ATTRACT2, "SE-M-ATTRACT2") \
+    X(SE_M_MORNING_SUN, "SE-M-MORNING-SUN") \
+    X(SE_M_FLATTER, "SE-M-FLATTER") \
+    X(SE_M_SAND_TOMB, "SE-M-SAND-TOMB") \
+    X(SE_M_GRASSWHISTLE, "SE-M-GRASSWHISTLE") \
+    X(SE_M_SPIT_UP, "SE-M-SPIT-UP") \
+    X(SE_M_DIVE, "SE-M-DIVE") \
+    X(SE_M_EARTHQUAKE, "SE-M-EARTHQUAKE") \
+    X(SE_M_TWISTER, "SE-M-TWISTER") \
+    X(SE_M_SWEET_SCENT, "SE-M-SWEET-SCENT") \
+    X(SE_M_YAWN, "SE-M-YAWN") \
+    X(SE_M_SKY_UPPERCUT, "SE-M-SKY-UPPERCUT") \
+    X(SE_M_STAT_INCREASE, "SE-M-STAT-INCREASE") \
+    X(SE_M_HEAT_WAVE, "SE-M-HEAT-WAVE") \
+    X(SE_M_UPROAR, "SE-M-UPROAR") \
+    X(SE_M_HAIL, "SE-M-HAIL") \
+    X(SE_M_COSMIC_POWER, "SE-M-COSMIC-POWER") \
+    X(SE_M_TEETER_DANCE, "SE-M-TEETER-DANCE") \
+    X(SE_M_STAT_DECREASE, "SE-M-STAT-DECREASE") \
+    X(SE_M_HAZE, "SE-M-HAZE") \
+    X(SE_M_HYPER_BEAM2, "SE-M-HYPER-BEAM2") \
+    X(SE_RG_DOOR, "SE-RG-DOOR") \
+    X(SE_RG_CARD_FLIP, "SE-RG-CARD-FLIP") \
+    X(SE_RG_CARD_FLIPPING, "SE-RG-CARD-FLIPPING") \
+    X(SE_RG_CARD_OPEN, "SE-RG-CARD-OPEN") \
+    X(SE_RG_BAG_CURSOR, "SE-RG-BAG-CURSOR") \
+    X(SE_RG_BAG_POCKET, "SE-RG-BAG-POCKET") \
+    X(SE_RG_BALL_CLICK, "SE-RG-BALL-CLICK") \
+    X(SE_RG_SHOP, "SE-RG-SHOP") \
+    X(SE_RG_SS_ANNE_HORN, "SE-RG-SS-ANNE-HORN") \
+    X(SE_RG_HELP_OPEN, "SE-RG-HELP-OPEN") \
+    X(SE_RG_HELP_CLOSE, "SE-RG-HELP-CLOSE") \
+    X(SE_RG_HELP_ERROR, "SE-RG-HELP-ERROR") \
+    X(SE_RG_DEOXYS_MOVE, "SE-RG-DEOXYS-MOVE") \
+    X(SE_RG_POKE_JUMP_SUCCESS, "SE-RG-POKE-JUMP-SUCCESS") \
+    X(SE_RG_POKE_JUMP_FAILURE, "SE-RG-POKE-JUMP-FAILURE") \
+    X(SE_PHONE_CALL, "SE-PHONE-CALL") \
+    X(SE_PHONE_CLICK, "SE-PHONE-CLICK") \
+    X(SE_ARENA_TIMEUP1, "SE-ARENA-TIMEUP1") \
+    X(SE_ARENA_TIMEUP2, "SE-ARENA-TIMEUP2") \
+    X(SE_PIKE_CURTAIN_CLOSE, "SE-PIKE-CURTAIN-CLOSE") \
+    X(SE_PIKE_CURTAIN_OPEN, "SE-PIKE-CURTAIN-OPEN") \
+    X(SE_SUDOWOODO_SHAKE, "SE-SUDOWOODO-SHAKE") \
+
+// Create BGM list
+#define X(songId, name) static const u8 sBGMName_##songId[] = _(name);
+SOUND_LIST_BGM
+#undef X
+
+#define X(songId, name) sBGMName_##songId,
+static const u8 *const gBGMNames[] =
+{
+SOUND_LIST_BGM
+};
+#undef X
+
+// Create SE list
+#define X(songId, name) static const u8 sSEName_##songId[] = _(name);
+SOUND_LIST_SE
+#undef X
+
+#define X(songId, name) sSEName_##songId,
+static const u8 *const gSENames[] =
+{
+SOUND_LIST_SE
+};
+#undef X
+
+// *******************************
+// Actions Other
+static void Task_WaitFadeAccessPC(u8 taskId)
+{
+    if (!gPaletteFade.active)
+    {
+        DestroyTask(taskId);
+        FlagSet(FLAG_SYS_PC_FROM_DEBUG_MENU);
+        EnterPokeStorage(2);
+    }
+}
+static void DebugAction_AccessPC(u8 taskId)
+{
+    Debug_DestroyMenu_Full(taskId);
+    CleanupOverworldWindowsAndTilemaps();
+    BeginNormalPaletteFade(0xFFFFFFFF, 0, 0, 16, RGB_BLACK);
+    CreateTask(Task_WaitFadeAccessPC, 0);
+}
+
+#endif

--- a/src/debug_pokemon_creator.c
+++ b/src/debug_pokemon_creator.c
@@ -1,0 +1,2075 @@
+// Port of Watanabe Debug Menu -> Create Pokémon Menu
+/* TODO Known Bugs and Todo List:
+    * Nickname length can't be changed
+Things that are not implemented yet, or bugs that are caused by unimplemented features:
+    * PP are not recalculated when editing PP Up count or moves.
+    * Only one of the sleep and toxic counter should be visible and editable at one time, but only if the status is sleep or toxic respectively. (This does not take the separate indexes for these two values into consideration.)
+    * Language, Origin Game, Met Location, Ball, and Nature (the unused separate index) should be drawn with their names next to them.
+    * If the Pokérus Strain is 0, the Days indexes should not be accessible.
+    * Setting "Egg" from Off to On should also update "Egg2", but setting "Egg2" to Off should NOT update "Egg". Also, setting "Egg" to Off should NOT update "Egg2".
+    * Add a "Bad Egg" index as an alternate value for "Present".
+    * In edit mode, pressing Select should reset that value; in mode 0, to default; else to that of the mon being edited.
+    * If the mon being created would be Shiny, draw a star next to the nickname.
+    * Dynamic max values:
+        * PP (With max PP for that move including PP Up boosts)
+        * Current HP (with max HP)
+        * EXP (with EXP at level 100 for that species)
+    * Binary and octal display modes
+    * Draw the mon's icon next to the species
+    * An actual cursor (instead of just highlighting the selected option)
+*/
+#include "global.h"
+#include "battle_main.h"
+#include "data.h"
+#include "debug.h"
+#include "item.h"
+#include "list_menu.h"
+#include "main.h"
+#include "menu.h"
+#include "pokemon.h"
+#include "pokemon_summary_screen.h"
+#include "pokemon_storage_system.h"
+#include "random.h"
+#include "region_map.h"
+#include "script.h"
+#include "sound.h"
+#include "strings.h"
+#include "string_util.h"
+#include "mini_printf.h"
+#include "gba/isagbprint.h"
+#include "constants/songs.h"
+#include "constants/items.h"
+#include "constants/moves.h"
+#include "constants/battle.h"
+#include "constants/region_map_sections.h"
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+
+static void DebugPkmCreator_Init_SetDefaults(void);
+static void DebugPkmCreator_Init_SetDefaults(void);
+static void DebugPkmCreator_Init_SetNewMonData(bool8 setMoves);
+static void DebugPkmCreator_PopulateDataStruct(void);
+static void DebugPkmCreator_Redraw(void);
+static void DebugPkmCreator_EditModeRedraw(u32, u8);
+static void DebugPkmCreator_ProcessInput(u8);
+static void DebugPkmCreator_EditModeProcessInput(u8);
+static u8 DebugPkmCreator_GiveToPlayer(void);
+
+static const u8 Str_Species[] = _("Species");
+static const u8 Str_Personality[] = _("PID/Nature/Gender");
+static const u8 Str_TrainerID[] = _("TID/SID/OT Gender");
+static const u8 Str_SecretID[] = _("SID");
+static const u8 Str_OT[] = _("OT Name");
+static const u8 Str_Nick[] = _("Nickname");
+static const u8 Str_Gender[] = _("Gender");
+static const u8 Str_Nature[] = _("Nature");
+static const u8 Str_Egg[] = _("Egg");
+static const u8 Str_Egg2[] = _("Egg2");
+static const u8 Str_HasSpecies[] = _("Present");
+static const u8 Str_Language[] = _("Language");
+static const u8 Str_Game[] = _("Origin Game");
+static const u8 Str_Item[] = _("Held Item");
+static const u8 Str_Level[] = _("Level");
+static const u8 Str_EXP[] = _("Experience/Level");
+static const u8 Str_Ability[] = _("Ability");
+static const u8 Str_Friendship[] = _("Friendship");
+static const u8 Str_MetLevel[] = _("Met Level");
+static const u8 Str_MetLocation[] = _("Met Location");
+static const u8 Str_Ball[] = _("Ball");
+static const u8 Str_PKrus[] = _("{PK}Rus Id/Dura/Left");
+static const u8 Str_HP[] = _("HP");
+static const u8 Str_Atk[] = _("Atk");
+static const u8 Str_Def[] = _("Def");
+static const u8 Str_Spe[] = _("Spe");
+static const u8 Str_SpA[] = _("SpA");
+static const u8 Str_SpD[] = _("SpD");
+static const u8 Str_HP_IV_EV[] = _("HP IV/EV/Now/Max");
+static const u8 Str_Atk_IV_EV[] = _("Atk IV/EV/Res");
+static const u8 Str_Def_IV_EV[] = _("Def IV/EV/Res");
+static const u8 Str_Spe_IV_EV[] = _("Spd IV/EV/Res");
+static const u8 Str_SpA_IV_EV[] = _("Sp. Atk IV/EV/Res");
+static const u8 Str_SpD_IV_EV[] = _("Sp. Def IV/EV/Res");
+static const u8 Str_EV[] = _("EV");
+static const u8 Str_IV[] = _("IV");
+static const u8 Str_Current[] = _("Current");
+static const u8 Str_Status[] = _("Status");
+static const u8 Str_Cool[] = _("Cool");
+static const u8 Str_Cute[] = _("Cute");
+static const u8 Str_Tough[] = _("Tough");
+static const u8 Str_Beauty[] = _("Beauty");
+static const u8 Str_Smart[] = _("Smart");
+static const u8 Str_Sheen[] = _("Sheen");
+static const u8 Str_Fateful[] = _("Fateful");
+static const u8 Str_Fateful2[] = _("Unused Ribbons");
+static const u8 Str_CoolRibbon[] = _("Cool Ribbons");
+static const u8 Str_CuteRibbon[] = _("Cute Ribbons");
+static const u8 Str_ToughRibbon[] = _("Tough Ribbons");
+static const u8 Str_BeautyRibbon[] = _("Beauty Ribbons");
+static const u8 Str_SmartRibbon[] = _("Smart Ribbons");
+static const u8 Str_ChampRibbon[] = _("Champion Ribbon");
+static const u8 Str_WinRibbon[] = _("Winning Ribbon");
+static const u8 Str_VictoryRibbon[] = _("Victory Ribbon");
+static const u8 Str_ArtistRibbon[] = _("Artist Ribbon");
+static const u8 Str_EffortRibbon[] = _("Effort Ribbon");
+static const u8 Str_GiftRibbon[] = _("Gift Ribbons");
+static const u8 Str_Move[] = _("Move");
+static const u8 Str_PP[] = _("PP");
+static const u8 Str_PPUp[] = _("PP Up");
+
+static const u8 Str_On[] = _("On");
+static const u8 Str_Off[] = _("Off");
+static const u8 Str_HexPrefix[] = _("0x");
+
+static const u8 Str_Header_Create[] = _("{COLOR GREEN}Create Pokémon");
+static const u8 Str_Header_Edit[] = _("{COLOR GREEN}Edit Pokémon");
+static const u8 Str_Header2[] = _("{START_BUTTON} Save & exit {DPAD_LEFTRIGHT} Page");
+
+static const u8 Str_DefaultOTName[8] = _("Debug-E");
+
+static const u8 Str_Page[] = _("Page: {STR_VAR_1}");
+static const u8 Str_Slot[] = _("Slot: {STR_VAR_1}");
+
+static const u8 Str_StringVars[] = _("{STR_VAR_1}{STR_VAR_3}");
+static const u8 Str_Spacer1[] = _(": {CLEAR_TO 100}");
+static const u8 Str_CursorColor[] = _("{COLOR GREEN}");
+static const u8 Str_Cursor2Color[] = _("{COLOR DARK_GRAY}{HIGHLIGHT LIGHT_BLUE}");
+static const u8 Str_CursorColorOff[] = _("{HIGHLIGHT WHITE}{COLOR GREEN}");
+static const u8 Str_JpnCharset[] = _("{JPN}");
+
+static const u8 Str_Genderless[] = _("-");
+static const u8 Str_Male[] = _("♂");
+static const u8 Str_Female[] = _("♀");
+static const u8 *const GenderIndexes[3] = {
+    Str_Male,
+    Str_Female,
+    Str_Genderless
+};
+
+static const u8 Str_Empty[] = _("");
+static const u8 Str_isShiny[] = _("{TRIANGLE}");
+static const u8 *const IsShinyIndex[2] = {
+    Str_Empty,
+    Str_isShiny
+};
+
+static const u8 Str_None[] = _("---");
+static const u8 Str_Psn[] = _("PSN");
+static const u8 Str_Par[] = _("PAR");
+static const u8 Str_Brn[] = _("BRN");
+static const u8 Str_Slp[] = _("SLP");
+static const u8 Str_Frz[] = _("FRZ");
+static const u8 Str_Psn2[] = _("PSN2");
+
+static const u8 *const StatusIndexes[7] = {
+    Str_None,
+    Str_Psn,
+    Str_Par,
+    Str_Brn,
+    Str_Slp,
+    Str_Frz,
+    Str_Psn2
+};
+
+struct EditPokemonStruct {
+    const u8* text;
+    u32 mode;
+    u32 min;
+    u32 max;
+    u32 initial;
+    u16 SetMonDataParam;
+    u16 digitCount;
+};
+
+enum {
+    EDIT_NULL,
+    EDIT_NORMAL,
+    EDIT_READONLY,
+    EDIT_STRING,
+    EDIT_BOOL,
+    EDIT_HEX,
+};
+
+enum {
+    VAL_SPECIES,
+    VAL_PID,
+    VAL_TID,
+    VAL_SID,
+    VAL_OT,
+    VAL_OT_GENDER,
+    VAL_NICK,
+    VAL_PKM_GENDER,
+    VAL_NATURE,
+    VAL_EGG,
+    VAL_EGG2,
+    VAL_HASSPECIES,
+    VAL_LANGUAGE,
+    VAL_GAME,
+    VAL_ITEM,
+    VAL_LEVEL,
+    VAL_EXP,
+    VAL_ABILITY,
+    VAL_FRIENDSHIP,
+    VAL_METLVL,
+    VAL_METLOCATATION,
+    VAL_BALL,
+    VAL_PKRUS_STRAIN,
+    VAL_PKRUS_DAYS_DEF,
+    VAL_PKRUS_DAYS_LEFT,
+    VAL_HP_CURRENT,
+    VAL_HP_MAX,
+    VAL_ATK,
+    VAL_DEF,
+    VAL_SPEED,
+    VAL_SPATK,
+    VAL_SPDEF,
+    VAL_HP_IV,
+    VAL_ATK_IV,
+    VAL_DEF_IV,
+    VAL_SPEED_IV,
+    VAL_SPATK_IV,
+    VAL_SPDEF_IV,
+    VAL_HP_EV,
+    VAL_ATK_EV,
+    VAL_DEF_EV,
+    VAL_SPEED_EV,
+    VAL_SPATK_EV,
+    VAL_SPDEF_EV,
+    VAL_COOL,
+    VAL_CUTE,
+    VAL_BEAUTY,
+    VAL_SMART,
+    VAL_TOUGH,
+    VAL_SHEEN,
+    VAL_STATUS,
+    VAL_SLEEP_TIMER,
+    VAL_PSN2_TIMER,
+    VAL_RIBBON_CHAMPRIBBON,
+    VAL_RIBBON_WINRIBBON,
+    VAL_RIBBON_VICTORYRIBBON,
+    VAL_RIBBON_ARTISTRIBBON,
+    VAL_RIBBON_EFFORTRIBBON,
+    VAL_RIBBON_COOLRIBBON,
+    VAL_RIBBON_CUTERIBBON,
+    VAL_RIBBON_BEAUTYRIBBON,
+    VAL_RIBBON_SMARTRIBBON,
+    VAL_RIBBON_TOUGHRIBBON,
+    VAL_RIBBON_GIFTRIBBON,
+    VAL_RIBBON_FATEFUL2,
+    VAL_MOVE_1,
+    VAL_MOVE_2,
+    VAL_MOVE_3,
+    VAL_MOVE_4,
+    VAL_MOVE_1_PP,
+    VAL_MOVE_2_PP,
+    VAL_MOVE_3_PP,
+    VAL_MOVE_4_PP,
+    VAL_MOVE_1_PPUP,
+    VAL_MOVE_2_PPUP,
+    VAL_MOVE_3_PPUP,
+    VAL_MOVE_4_PPUP,
+    VAL_IS_SHINY,
+};
+
+#define PAGE_COUNT 7
+
+// text, mode, min value, max value, initial value, SetMonDataParam, digitCount
+static const struct EditPokemonStruct DebugPkmCreator_Options[] =
+{
+        [VAL_SPECIES]              = {Str_Species, EDIT_NORMAL, 1, NUM_SPECIES-1, SPECIES_BULBASAUR, MON_DATA_SPECIES, 4},
+        [VAL_PID]                  = {Str_Personality, EDIT_HEX, 0, 0xffffffff, 0, MON_DATA_PERSONALITY, 8},
+        [VAL_TID]                  = {Str_TrainerID, EDIT_NORMAL, 0, 0xffff, 0, MON_DATA_OT_ID, 5},
+        [VAL_SID]                  = {Str_SecretID, EDIT_NORMAL, 0, 0xffff, 0, MON_DATA_OT_ID, 5}, // SID
+        [VAL_OT]                   = {Str_OT, EDIT_STRING, 0, 0, 0, MON_DATA_OT_NAME, PLAYER_NAME_LENGTH}, // We can't set a default here because the saveblock pointer can change.
+        [VAL_OT_GENDER]            = {Str_Gender, EDIT_NORMAL, 0, 1, 0, MON_DATA_OT_GENDER, 1},
+        [VAL_NICK]                 = {Str_Nick, EDIT_STRING, 0, 0, 0, MON_DATA_NICKNAME, POKEMON_NAME_LENGTH},
+        [VAL_PKM_GENDER]           = {Str_Gender, EDIT_READONLY, 0, 2, 0, MON_DATA_PERSONALITY, 1},
+        [VAL_NATURE]               = {Str_Nature, EDIT_READONLY, 0, 24, 0, MON_DATA_PERSONALITY, 2},
+        [VAL_EGG]                  = {Str_Egg, EDIT_BOOL, 0, 1, 0, MON_DATA_IS_EGG, 1},
+        [VAL_EGG2]                 = {Str_Egg2, EDIT_BOOL, 0, 1, 0, MON_DATA_SANITY_IS_EGG, 1},
+        [VAL_HASSPECIES]           = {Str_HasSpecies, EDIT_BOOL, 0, 1, 1, MON_DATA_SANITY_HAS_SPECIES, 1},
+        [VAL_LANGUAGE]             = {Str_Language, EDIT_NORMAL, 0, NUM_LANGUAGES - 1, GAME_LANGUAGE, MON_DATA_LANGUAGE, 2},
+        [VAL_GAME]                 = {Str_Game, EDIT_NORMAL, 0, 49, GAME_VERSION, MON_DATA_MET_GAME, 2}, // 45 = Shield
+        [VAL_ITEM]                 = {Str_Item, EDIT_NORMAL, 0, ITEMS_COUNT - 1, 0, MON_DATA_HELD_ITEM, 3},
+        [VAL_LEVEL]                = {Str_Level, EDIT_NORMAL, 0, 100, 10, MON_DATA_LEVEL, 3},
+        [VAL_EXP]                  = {Str_EXP, EDIT_NORMAL, 0, 1640000, 1000, MON_DATA_EXP, 7},
+        [VAL_ABILITY]              = {Str_Ability, EDIT_NORMAL, 0, 2, 0, MON_DATA_ABILITY_NUM, 1},
+        [VAL_FRIENDSHIP]           = {Str_Friendship, EDIT_NORMAL, 0, 255, 0, MON_DATA_FRIENDSHIP, 3},
+        [VAL_METLVL]               = {Str_MetLevel, EDIT_NORMAL, 0, 100, 10, MON_DATA_MET_LEVEL, 3}, // 0 instead of 1 because 0 means hatched from an Egg
+        [VAL_METLOCATATION]        = {Str_MetLocation, EDIT_NORMAL, 0, 65535, MAPSEC_LITTLEROOT_TOWN, MON_DATA_MET_LOCATION, 5},
+        [VAL_BALL]                 = {Str_Ball, EDIT_NORMAL, 0, LAST_BALL, ITEM_POKE_BALL, MON_DATA_POKEBALL, 2},
+        [VAL_PKRUS_STRAIN]         = {Str_PKrus, EDIT_NORMAL, 0, 3, 0, MON_DATA_POKERUS, 1}, // 4 different "strains"
+        [VAL_PKRUS_DAYS_DEF]       = {Str_PKrus, EDIT_NORMAL, 1, 4, 1, MON_DATA_POKERUS, 1}, // "default" days until cured
+        [VAL_PKRUS_DAYS_LEFT]      = {Str_PKrus, EDIT_NORMAL, 0, 7, 0, MON_DATA_POKERUS, 1}, // Days until cured
+        // Current stats
+        [VAL_HP_CURRENT]           = {Str_HP, EDIT_NORMAL, 0, 999, 0, MON_DATA_HP, 3},
+        [VAL_HP_MAX]               = {Str_HP, EDIT_READONLY, 0, 999, 0, MON_DATA_MAX_HP, 3},
+        [VAL_ATK]                  = {Str_Atk, EDIT_READONLY, 0, 999, 0, MON_DATA_ATK, 3},
+        [VAL_DEF]                  = {Str_Def, EDIT_READONLY, 0, 999, 0, MON_DATA_DEF, 3},
+        [VAL_SPEED]                = {Str_Spe, EDIT_READONLY, 0, 999, 0, MON_DATA_SPEED, 3},
+        [VAL_SPATK]                = {Str_SpA, EDIT_READONLY, 0, 999, 0, MON_DATA_SPATK, 3},
+        [VAL_SPDEF]                = {Str_SpD, EDIT_READONLY, 0, 999, 0, MON_DATA_SPDEF, 3},
+        // IVs
+        [VAL_HP_IV]                = {Str_HP_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_HP_IV, 2},
+        [VAL_ATK_IV]               = {Str_Atk_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_ATK_IV, 2},
+        [VAL_DEF_IV]               = {Str_Def_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_DEF_IV, 2},
+        [VAL_SPEED_IV]             = {Str_Spe_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_SPEED_IV, 2},
+        [VAL_SPATK_IV]             = {Str_SpA_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_SPATK_IV, 2},
+        [VAL_SPDEF_IV]             = {Str_SpD_IV_EV, EDIT_NORMAL, 0, 31, 0, MON_DATA_SPDEF_IV, 2},
+        // EVs
+        [VAL_HP_EV]                = {Str_HP_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_HP_EV, 3},
+        [VAL_ATK_EV]               = {Str_Atk_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_ATK_EV, 3},
+        [VAL_DEF_EV]               = {Str_Def_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_DEF_EV, 3},
+        [VAL_SPEED_EV]             = {Str_Spe_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_SPEED_EV, 3},
+        [VAL_SPATK_EV]             = {Str_SpA_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_SPATK_EV, 3},
+        [VAL_SPDEF_EV]             = {Str_SpD_IV_EV, EDIT_NORMAL, 0, 255, 0, MON_DATA_SPDEF_EV, 3},
+        // Contest Stats
+        [VAL_COOL]                 = {Str_Cool, EDIT_NORMAL, 0, 255, 0, MON_DATA_COOL, 3},
+        [VAL_CUTE]                 = {Str_Cute, EDIT_NORMAL, 0, 255, 0, MON_DATA_CUTE, 3},
+        [VAL_BEAUTY]               = {Str_Beauty, EDIT_NORMAL, 0, 255, 0, MON_DATA_BEAUTY, 3},
+        [VAL_SMART]                = {Str_Smart, EDIT_NORMAL, 0, 255, 0, MON_DATA_SMART, 3},
+        [VAL_TOUGH]                = {Str_Tough, EDIT_NORMAL, 0, 255, 0, MON_DATA_TOUGH, 3},
+        [VAL_SHEEN]                = {Str_Sheen, EDIT_NORMAL, 0, 255, 0, MON_DATA_SHEEN, 3},
+        [VAL_STATUS]               = {Str_Status, EDIT_NORMAL, 0, 6, 0, MON_DATA_STATUS, 1},
+        [VAL_SLEEP_TIMER]          = {Str_Slp, EDIT_NORMAL, 0, 7, 0, MON_DATA_STATUS, 1}, // sleep timer
+        [VAL_PSN2_TIMER]           = {Str_Psn2, EDIT_NORMAL, 0, 15, 0, MON_DATA_STATUS, 2}, // badly poisoned timer
+        // Ribbons
+        [VAL_RIBBON_CHAMPRIBBON]   = {Str_ChampRibbon, EDIT_BOOL, 0, 1, 0, MON_DATA_CHAMPION_RIBBON, 1},
+        [VAL_RIBBON_WINRIBBON]     = {Str_WinRibbon, EDIT_BOOL, 0, 1, 0, MON_DATA_WINNING_RIBBON, 1},
+        [VAL_RIBBON_VICTORYRIBBON] = {Str_VictoryRibbon, EDIT_BOOL, 0, 1, 0, MON_DATA_VICTORY_RIBBON, 1},
+        [VAL_RIBBON_ARTISTRIBBON]  = {Str_ArtistRibbon, EDIT_BOOL, 0, 1, 0, MON_DATA_ARTIST_RIBBON, 1},
+        [VAL_RIBBON_EFFORTRIBBON]  = {Str_EffortRibbon, EDIT_BOOL, 0, 1, 0, MON_DATA_EFFORT_RIBBON, 1},
+        [VAL_RIBBON_COOLRIBBON]    = {Str_CoolRibbon, EDIT_NORMAL, 0, 3, 0, MON_DATA_COOL_RIBBON, 1},
+        [VAL_RIBBON_CUTERIBBON]    = {Str_CuteRibbon, EDIT_NORMAL, 0, 3, 0, MON_DATA_CUTE_RIBBON, 1},
+        [VAL_RIBBON_BEAUTYRIBBON]  = {Str_BeautyRibbon, EDIT_NORMAL, 0, 3, 0, MON_DATA_BEAUTY_RIBBON, 1},
+        [VAL_RIBBON_SMARTRIBBON]   = {Str_SmartRibbon, EDIT_NORMAL, 0, 3, 0, MON_DATA_SMART_RIBBON, 1},
+        [VAL_RIBBON_TOUGHRIBBON]   = {Str_ToughRibbon, EDIT_NORMAL, 0, 3, 0, MON_DATA_TOUGH_RIBBON, 1},
+        [VAL_RIBBON_GIFTRIBBON]    = {Str_GiftRibbon, EDIT_HEX, 0, 127, 0, MON_DATA_MARINE_RIBBON, 2},
+        [VAL_RIBBON_FATEFUL2]      = {Str_Fateful2, EDIT_NORMAL, 0, 3, 0, MON_DATA_UNUSED_RIBBONS, 1},
+        // Move data
+        [VAL_MOVE_1]               = {Str_Move, EDIT_NORMAL, 0, MOVES_COUNT - 1, MOVE_POUND, MON_DATA_MOVE1, 3},
+        [VAL_MOVE_2]               = {Str_Move, EDIT_NORMAL, 0, MOVES_COUNT - 1, 0, MON_DATA_MOVE2, 3},
+        [VAL_MOVE_3]               = {Str_Move, EDIT_NORMAL, 0, MOVES_COUNT - 1, 0, MON_DATA_MOVE3, 3},
+        [VAL_MOVE_4]               = {Str_Move, EDIT_NORMAL, 0, MOVES_COUNT - 1, 0, MON_DATA_MOVE4, 3},
+        [VAL_MOVE_1_PP]            = {Str_PP, EDIT_NORMAL, 0, 99, 40, MON_DATA_PP1, 2},
+        [VAL_MOVE_2_PP]            = {Str_PP, EDIT_NORMAL, 0, 99, 40, MON_DATA_PP2, 2},
+        [VAL_MOVE_3_PP]            = {Str_PP, EDIT_NORMAL, 0, 99, 40, MON_DATA_PP3, 2},
+        [VAL_MOVE_4_PP]            = {Str_PP, EDIT_NORMAL, 0, 99, 40, MON_DATA_PP4, 2},
+        [VAL_MOVE_1_PPUP]          = {Str_PPUp, EDIT_NORMAL, 0, 3, 0, MON_DATA_PP_BONUSES, 1},
+        [VAL_MOVE_2_PPUP]          = {Str_PPUp, EDIT_NORMAL, 0, 3, 0, MON_DATA_PP_BONUSES, 1},
+        [VAL_MOVE_3_PPUP]          = {Str_PPUp, EDIT_NORMAL, 0, 3, 0, MON_DATA_PP_BONUSES, 1},
+        [VAL_MOVE_4_PPUP]          = {Str_PPUp, EDIT_NORMAL, 0, 3, 0, MON_DATA_PP_BONUSES, 1},
+        [VAL_IS_SHINY]             = {Str_Nature, EDIT_READONLY, 0, 1, 0, MON_DATA_PERSONALITY, 1},
+};
+
+#define EDIT_OPTION_COUNT ARRAY_COUNT(DebugPkmCreator_Options)
+
+static const u8 DebugPkmCreator_Pages[PAGE_COUNT + 1][7] =
+{
+    {VAL_SPECIES, VAL_LEVEL, VAL_TID, VAL_PID, VAL_NICK, VAL_OT, 0xFF},
+    {VAL_STATUS, VAL_FRIENDSHIP, VAL_PKRUS_STRAIN, VAL_EGG, VAL_EGG2, VAL_HASSPECIES, 0xFF},
+    {VAL_MOVE_1, VAL_MOVE_2, VAL_MOVE_3, VAL_MOVE_4, VAL_ITEM, VAL_ABILITY, 0xFF},
+    {VAL_HP_IV, VAL_ATK_IV, VAL_DEF_IV, VAL_SPEED_IV, VAL_SPATK_IV, VAL_SPDEF_IV, 0xFF},
+    {VAL_COOL, VAL_CUTE, VAL_BEAUTY, VAL_SMART, VAL_TOUGH, VAL_SHEEN, 0xFF},
+    {VAL_RIBBON_COOLRIBBON, VAL_RIBBON_CUTERIBBON, VAL_RIBBON_BEAUTYRIBBON, VAL_RIBBON_SMARTRIBBON, VAL_RIBBON_TOUGHRIBBON, VAL_RIBBON_ARTISTRIBBON, 0xFF},
+    {VAL_RIBBON_CHAMPRIBBON, VAL_RIBBON_WINRIBBON, VAL_RIBBON_VICTORYRIBBON, VAL_RIBBON_EFFORTRIBBON, VAL_RIBBON_GIFTRIBBON, 0xFF},
+    {VAL_LANGUAGE, VAL_GAME, VAL_METLVL, VAL_METLOCATATION, VAL_BALL, VAL_RIBBON_FATEFUL2, 0xFF},
+};
+
+static const u8 DebugPkmCreator_AltIndexes[PAGE_COUNT + 1][6][3] =
+{
+    {
+        {VAL_PKM_GENDER, 0xFF, 0xFF},
+        {VAL_EXP, 0xFF, 0xFF},
+        {VAL_SID, VAL_OT_GENDER, 0xFF},
+        {VAL_NATURE, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {VAL_PKRUS_DAYS_DEF, VAL_PKRUS_DAYS_LEFT, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {VAL_MOVE_1_PP, VAL_MOVE_1_PPUP, 0xFF},
+        {VAL_MOVE_2_PP, VAL_MOVE_2_PPUP, 0xFF},
+        {VAL_MOVE_3_PP, VAL_MOVE_3_PPUP, 0xFF},
+        {VAL_MOVE_4_PP, VAL_MOVE_4_PPUP, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {VAL_HP_EV, VAL_HP_CURRENT, VAL_HP_MAX},
+        {VAL_ATK_EV, VAL_ATK, 0xFF},
+        {VAL_DEF_EV, VAL_DEF, 0xFF},
+        {VAL_SPEED_EV, VAL_SPEED, 0xFF},
+        {VAL_SPATK_EV, VAL_SPATK, 0xFF},
+        {VAL_SPDEF_EV, VAL_SPDEF, 0xFF},
+    },
+    {
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+    {
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+        {0xFF, 0xFF, 0xFF},
+    },
+};
+
+struct PokemonCreator
+{
+    struct Pokemon mon;
+    struct Pokemon* monBeingEdited;
+    u16 index;
+    u16 mode;
+    u32 data[EDIT_OPTION_COUNT];
+    u8 currentPage;
+    u8 selectedOption;
+    u8 headerWindowId;
+    u8 menuWindowId;
+};
+
+static EWRAM_DATA struct PokemonCreator sDebugPkmCreatorData = {0};
+static EWRAM_DATA u8 DebugPkmCreator_NameBuffer[16] = {0};
+static EWRAM_DATA u32 DebugPkmCreator_editingVal[4] = {0};
+
+static const struct WindowTemplate DebugPkmCreator_HeaderWindowTemplate =
+{
+    .bg = 0,
+    .tilemapLeft = 1,
+    .tilemapTop = 1,
+    .width = 28,
+    .height = 2,
+    .baseBlock = 1,
+    .paletteNum = 15
+};
+
+static const struct WindowTemplate DebugPkmCreator_FullScreenWindowTemplate =
+{
+    .bg = 0,
+    .tilemapLeft = 1,
+    .tilemapTop = 5,
+    .width = 28,
+    .height = 14,
+    .baseBlock = 57,
+    .paletteNum = 15
+};
+
+
+/*
+    Mode List:
+    *  0 - Add to party
+    *  1 - Edit party
+    *  2 - Edit PC Box
+    *  3 - Edit enemy party (usable as a sandbox)
+    *  4 - Edit enemy party for debug battle
+    *  5 - Edit party for debug battle
+    *  6 - Add to enemy party (Unused)
+    *  7 - Testing mode (Don't alter parties)
+    *  8 - Testing mode (use first mon as template)
+    *  9 - For battle debug menu: Edit enemy party
+    * 10 - For battle debug menu: Edit enemy party as specified index
+*/
+void DebugPkmCreator_Init(u8 mode, u8 index)
+{
+    struct Pokemon* mons;
+    u32 i;
+    sDebugPkmCreatorData.mode = mode;
+    switch (mode) {
+    case 0:
+    case 6:
+        mons = &gEnemyParty[0];
+        ZeroMonData(mons); // Is this really necessary?
+        ZeroMonData(&sDebugPkmCreatorData.mon);
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        sDebugPkmCreatorData.index = 0;
+        break;
+    case 1:
+    case 5: // used in Debug Battle
+        mons = &gPlayerParty[sDebugPkmCreatorData.index];
+        if (mode == 1) 
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        break;
+    case 2:
+        mons = (struct Pokemon*) &gPokemonStoragePtr->boxes[0][sDebugPkmCreatorData.index];
+        CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct BoxPokemon));
+        CalculateMonStats(&sDebugPkmCreatorData.mon);
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        break;
+    case 3:
+    case 4: // used in Debug Battle
+        mons = &gEnemyParty[sDebugPkmCreatorData.index];
+        if (mode == 3)
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        break;
+    case 7:
+    case 8:
+    default:
+        if (mode == 8)
+            CopyMon(&sDebugPkmCreatorData.mon, &gPlayerParty[0], sizeof(struct Pokemon));
+        else
+            ZeroMonData(&sDebugPkmCreatorData.mon);
+        sDebugPkmCreatorData.monBeingEdited = &sDebugPkmCreatorData.mon;
+        sDebugPkmCreatorData.index = 0;
+        break;
+    case 9: // Add to enemy party
+        for (i = 0; i < PARTY_SIZE; i++)
+        {
+            if (GetMonData(&gEnemyParty[i], MON_DATA_SANITY_HAS_SPECIES))
+                continue;
+            else
+                break;
+        }
+        if (i >= PARTY_SIZE)
+            return;
+        mons = &gEnemyParty[i];
+        ZeroMonData(mons); // Is this really necessary?
+        ZeroMonData(&sDebugPkmCreatorData.mon);
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        sDebugPkmCreatorData.index = i;
+        break;
+    case 10: // Edit enemy party at index
+        sDebugPkmCreatorData.index = index;
+        mons = &gEnemyParty[sDebugPkmCreatorData.index];
+        CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+        sDebugPkmCreatorData.monBeingEdited = mons;
+        break;
+    }
+    // Set default data
+    if (mode == 0 || mode == 6 || mode == 7 || mode == 9)
+    {
+        SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_OT_NAME, Str_DefaultOTName);
+        DebugPkmCreator_Init_SetDefaults();
+    }
+    // Populate the editor data
+    DebugPkmCreator_PopulateDataStruct();
+    // Draw the editor menu
+    LoadMessageBoxAndBorderGfx();
+    sDebugPkmCreatorData.headerWindowId = AddWindow(&DebugPkmCreator_HeaderWindowTemplate);
+    DrawStdWindowFrame(sDebugPkmCreatorData.headerWindowId, FALSE);
+    CopyWindowToVram(sDebugPkmCreatorData.headerWindowId, 3);
+    AddTextPrinterParameterized(sDebugPkmCreatorData.headerWindowId, 1, mode == 0 ? Str_Header_Create : Str_Header_Edit, 0, 0, 0, NULL);
+    AddTextPrinterParameterized(sDebugPkmCreatorData.headerWindowId, 0, Str_Header2, 105, 0, 0, NULL);
+    sDebugPkmCreatorData.menuWindowId = AddWindow(&DebugPkmCreator_FullScreenWindowTemplate);
+    DrawStdWindowFrame(sDebugPkmCreatorData.menuWindowId, FALSE);
+    CopyWindowToVram(sDebugPkmCreatorData.menuWindowId, 3);
+    DebugPkmCreator_Redraw();
+    CreateTask(DebugPkmCreator_ProcessInput, 10);
+}
+
+static void DebugPkmCreator_Init_SetDefaults(void)
+{
+    u32 i;
+    for (i = 0; i < EDIT_OPTION_COUNT; i++)
+    {
+        switch (i)
+        {
+        default:
+            sDebugPkmCreatorData.data[i] = DebugPkmCreator_Options[i].initial;
+            break;
+        case VAL_PID:
+            sDebugPkmCreatorData.data[i] = Random32();
+            break;
+        case VAL_TID:
+            sDebugPkmCreatorData.data[i] = (*(u32*) &gSaveBlock2Ptr->playerTrainerId) & 0xffff;
+            break;
+        case VAL_SID:
+            sDebugPkmCreatorData.data[i] = (*(u32*) &gSaveBlock2Ptr->playerTrainerId) >> 16;
+            break;
+        case VAL_EXP:
+            sDebugPkmCreatorData.data[i] = gExperienceTables[gSpeciesInfo[DebugPkmCreator_Options[0].initial].growthRate][DebugPkmCreator_Options[15].initial];
+            break;
+        }
+    }
+    DebugPkmCreator_Init_SetNewMonData(TRUE);
+}
+
+static void DebugPkmCreator_Init_SetNewMonData(bool8 setMoves)
+{
+    struct Pokemon* mons = &sDebugPkmCreatorData.mon;
+    u32 data, i, j, k;
+    // Buffer the OT name
+    StringCopyN(DebugPkmCreator_NameBuffer, mons->box.otName, PLAYER_NAME_LENGTH);
+    data = (sDebugPkmCreatorData.data[3] << 16) | sDebugPkmCreatorData.data[2];
+    CreateMon(mons, sDebugPkmCreatorData.data[0], sDebugPkmCreatorData.data[15], 32, 1, sDebugPkmCreatorData.data[1], OT_ID_PRESET, data);
+    SetMonData(mons, MON_DATA_OT_NAME, DebugPkmCreator_NameBuffer);
+    data = ((sDebugPkmCreatorData.data[23] - 1) & 3) << 6;
+    data |= (sDebugPkmCreatorData.data[22] & 3) << 4;
+    data |= (sDebugPkmCreatorData.data[24] & 0xf);
+    SetMonData(mons, MON_DATA_POKERUS, &data);
+    for (i = 0; i < EDIT_OPTION_COUNT; i++)
+    {
+        switch (i)
+        {
+        default:
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        // All these should already be set (or will be set later)
+        case VAL_SPECIES ... VAL_OT: // PID, TID, OT
+        case VAL_NICK ... VAL_NATURE: // Nickname, gender, nature
+        case VAL_LEVEL:
+        case VAL_PKRUS_STRAIN ... VAL_PKRUS_DAYS_LEFT: // Pokérus
+        case VAL_HP_MAX ... VAL_SPDEF: // Current stats
+        case VAL_MOVE_1_PPUP ... VAL_MOVE_3_PPUP:
+        case VAL_IS_SHINY:
+            break;
+        // Only set after initial generation
+        case VAL_OT_GENDER:
+        case VAL_FRIENDSHIP: // Friendship (will always default to the base friendship of the default species)
+        case VAL_METLOCATATION:
+        case VAL_HP_CURRENT:
+            if (!setMoves)
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        case VAL_ABILITY:
+            if (setMoves)
+            {
+                if (gSpeciesInfo[sDebugPkmCreatorData.data[0]].abilities[1])
+                {
+                    data = sDebugPkmCreatorData.data[1] & 1;
+                    SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+                }
+                break;
+            }
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        case VAL_SPDEF_IV: // IVs
+            if (setMoves)
+            {
+                data = Random32();
+                SetMonData(mons, MON_DATA_IVS, &data);
+                break;
+            }
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        case VAL_STATUS:
+            j = sDebugPkmCreatorData.data[i];
+            switch (j)
+            {
+            case 0:
+            default:
+                data = 0;
+                break;
+            case 1:
+                data = STATUS1_POISON;
+                break;
+            case 2:
+                data = STATUS1_PARALYSIS;
+                break;
+            case 3:
+                data = STATUS1_BURN;
+                break;
+            case 4:
+                data = 3;
+                break;
+            case 5:
+                data = STATUS1_FREEZE;
+                break;
+            case 6:
+                data = STATUS1_TOXIC_POISON;
+                break;
+            }
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            break;
+        case VAL_SLEEP_TIMER:
+            if (sDebugPkmCreatorData.data[50] == 4)
+            {
+                data = sDebugPkmCreatorData.data[i];
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            }
+            break;
+        case VAL_PSN2_TIMER:
+            if (sDebugPkmCreatorData.data[i] == 6)
+            {
+                data = sDebugPkmCreatorData.data[i] << 8 | STATUS1_TOXIC_POISON;
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            }
+            break;
+        case VAL_RIBBON_GIFTRIBBON:
+            data = sDebugPkmCreatorData.data[i];
+            for (j = 0; j < 7; j++)
+            {
+                k = data & 1;
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam + j, &k);
+                data >>= 1;
+            }
+            break;
+        case VAL_MOVE_4: // Moves
+            if (setMoves)
+            {
+                GiveMonInitialMoveset(mons);
+                break;
+            }
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        case VAL_MOVE_4_PPUP: // PP Up count (74 through 76 are set too)
+            data = 0;
+            for (j = 0; j < 4; j++)
+            {
+                data <<= 2;
+                data |= (sDebugPkmCreatorData.data[74 + j] & 3);
+            }
+            SetMonData(mons, DebugPkmCreator_Options[74].SetMonDataParam, &data);
+            break;
+        }
+    }
+    if (setMoves) MonRestorePP(mons);
+    CalculateMonStats(mons);
+}
+
+static void DebugPkmCreator_SetMonData(void)
+{
+    struct Pokemon* mons = &sDebugPkmCreatorData.mon;
+    u32 data, i, j, k;
+    data = ((sDebugPkmCreatorData.data[23] - 1) & 3) << 6;
+    data |= (sDebugPkmCreatorData.data[22] & 3) << 4;
+    data |= (sDebugPkmCreatorData.data[24] & 0xf);
+    SetMonData(mons, MON_DATA_POKERUS, &data);
+    for (i = 0; i < EDIT_OPTION_COUNT; i++)
+    {
+        switch (i)
+        {
+        default:
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &sDebugPkmCreatorData.data[i]);
+            break;
+        case VAL_SPECIES ... VAL_OT: // PID and TID, leave alone. 0 is species, which we handle in a different function
+        case VAL_NICK ... VAL_NATURE: // Nickname (4) and OT name, set by the actual editor; 7-8 are gender and nature (readonly)
+        case VAL_LEVEL: // Level (set by CalculateMonStats)
+        case VAL_PKRUS_STRAIN ... VAL_PKRUS_DAYS_LEFT: // Pokérus (set above)
+        case VAL_HP_MAX ... VAL_SPATK: // Current stats (readonly). 31 calls CalculateMonStats
+        case VAL_MOVE_1_PPUP ... VAL_MOVE_3_PPUP: // PP Up counts (77 sets all at once)
+        case VAL_IS_SHINY:
+            break;
+        case 31: // Stats (and level)
+            CalculateMonStats(mons);
+            break;
+        case 50: // Status
+            j = sDebugPkmCreatorData.data[i];
+            switch (j)
+            {
+            case 0:
+            default:
+                data = 0;
+                break;
+            case 1:
+                data = STATUS1_POISON;
+                break;
+            case 2:
+                data = STATUS1_PARALYSIS;
+                break;
+            case 3:
+                data = STATUS1_BURN;
+                break;
+            case 4:
+                data = 3;
+                break;
+            case 5:
+                data = STATUS1_FREEZE;
+                break;
+            case 6:
+                data = STATUS1_TOXIC_POISON;
+                break;
+            }
+            SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            break;
+        case 51: // Sleep counter
+            if (sDebugPkmCreatorData.data[50] == 4)
+            {
+                data = sDebugPkmCreatorData.data[i];
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            }
+            break;
+        case 52: // Toxic counter
+            if (sDebugPkmCreatorData.data[i] == 6)
+            {
+                data = sDebugPkmCreatorData.data[i] << 8 | STATUS1_TOXIC_POISON;
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, &data);
+            }
+            break;
+        case 63: // Gift ribbons
+            data = sDebugPkmCreatorData.data[i];
+            for (j = 0; j < 7; j++)
+            {
+                k = data & 1;
+                SetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam + j, &k);
+                data >>= 1;
+            }
+            break;
+        case 76: // PP Up count (74 through 76 are set too)
+            data = 0;
+            for (j = 0; j < 4; j++)
+            {
+                data <<= 2;
+                data |= (sDebugPkmCreatorData.data[77 - j] & 3);
+            }
+            SetMonData(mons, DebugPkmCreator_Options[74].SetMonDataParam, &data);
+            break;
+        }
+    }
+}
+
+static void DebugPkmCreator_PopulateDataStruct(void)
+{
+    struct Pokemon* mons = &sDebugPkmCreatorData.mon;
+    u32 data, i, j;
+    for (i = 0; i < EDIT_OPTION_COUNT; i++)
+    {
+        switch (i)
+        {
+        default:
+            sDebugPkmCreatorData.data[i] = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            break;
+        case VAL_TID:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            sDebugPkmCreatorData.data[i] = data & 0xffff;
+            break;
+        case VAL_SID:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            sDebugPkmCreatorData.data[i] = data >> 16;
+            break;
+        case VAL_OT:
+            sDebugPkmCreatorData.data[i] = (u32) &mons->box.otName;
+            break;
+        case VAL_NICK:
+            sDebugPkmCreatorData.data[i] = (u32) &mons->box.nickname;
+            break;
+        case VAL_PKM_GENDER:
+            data = GetMonGender(mons);
+            if (data == MON_FEMALE)
+                data = 1;
+            else if (data == MON_GENDERLESS)
+                data = 2;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_NATURE:
+            sDebugPkmCreatorData.data[i] = GetNature(mons);
+            break;
+        case VAL_PKRUS_STRAIN:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            data &= 0x30;
+            data >>= 4;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_PKRUS_DAYS_DEF:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            data &= 0xc0;
+            data >>= 6;
+            sDebugPkmCreatorData.data[i] = data + 1;
+            break;
+        case VAL_PKRUS_DAYS_LEFT:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            data &= 0xf;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_STATUS:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            if (data & STATUS1_SLEEP)
+                data = 4;
+            else if (data & STATUS1_POISON)
+                data = 1;
+            else if (data & STATUS1_BURN)
+                data = 3;
+            else if (data & STATUS1_FREEZE)
+                data = 5;
+            else if (data & STATUS1_PARALYSIS)
+                data = 2;
+            else if (data & STATUS1_TOXIC_POISON)
+                data = 6;
+            else data = 0;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_SLEEP_TIMER:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            data &= STATUS1_SLEEP;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_PSN2_TIMER:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            data >>= 8;
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_RIBBON_GIFTRIBBON:
+            data = 0;
+            for (j = 0; j < 7; j++)
+            {
+                data <<= 1;
+                data |= GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam - 1 + (7 - j), NULL);
+            }
+            sDebugPkmCreatorData.data[i] = data;
+            break;
+        case VAL_MOVE_1_PPUP ... VAL_MOVE_4_PPUP:
+            data = GetMonData(mons, DebugPkmCreator_Options[i].SetMonDataParam, NULL);
+            j = (i - 74) * 2;
+            data >>= j;
+            sDebugPkmCreatorData.data[i] = data & 3;
+            break;
+        case VAL_IS_SHINY:
+            //GetMonData(&sDebugPkmCreatorData.mon, MON_DATA_PERSONALITY)
+            sDebugPkmCreatorData.data[i] = IsShinyOtIdPersonality(sDebugPkmCreatorData.data[VAL_OT], sDebugPkmCreatorData.data[VAL_PID]);
+            break;
+        }
+    }
+}
+
+// Draw Functions
+static void DebugPkmCreator_Redraw(void)
+{
+    u32 i;
+    u32 x = 0;
+    u32 y = 0;
+    u8* bufferPosition;
+    const u8* page = DebugPkmCreator_Pages[sDebugPkmCreatorData.currentPage];
+    const struct EditPokemonStruct* data;
+    u8 index;
+    ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.currentPage + 1, STR_CONV_MODE_LEFT_ALIGN, 2);
+    StringExpandPlaceholders(gStringVar2, Str_Page);
+    AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 0, gStringVar2, x, y, 0, NULL);
+    if ((sDebugPkmCreatorData.mode >= 1 && sDebugPkmCreatorData.mode <= 5) || sDebugPkmCreatorData.mode == 10) {
+        x = 100;
+        ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.index + 1, STR_CONV_MODE_LEFT_ALIGN, 2);
+        StringExpandPlaceholders(gStringVar2, Str_Slot);
+        AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 0, gStringVar2, x, y, 0, NULL);
+        x = 0;
+    }
+    y += 16;
+    for (i = 0; i < 6; i++)
+    {
+        bufferPosition = gStringVar2;
+        index = page[i];
+        if (index == 0xFF) break;
+        if (i == sDebugPkmCreatorData.selectedOption)
+        {
+            // Color the currently selected option green
+            bufferPosition = StringCopy(bufferPosition, Str_CursorColor);
+        }
+        data = &DebugPkmCreator_Options[index];
+        switch (index)
+        {
+        default:
+            switch (data->mode)
+            {
+            case EDIT_NORMAL:
+            case EDIT_READONLY:
+            default:
+                ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+                break;
+            case EDIT_HEX:
+                ConvertUIntToHexStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+                break;
+            case EDIT_NULL:
+                break;
+            case EDIT_BOOL:
+                StringCopy(gStringVar1, sDebugPkmCreatorData.data[index] ? Str_On : Str_Off);
+                break;
+            case EDIT_STRING:
+                StringCopyN(gStringVar1, (u8*) sDebugPkmCreatorData.data[index], data->digitCount);
+                // Pokémon names can sometimes be unterminated, so add an extra terminator here
+                gStringVar1[data->digitCount] = EOS;
+                break;
+            }
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            if (data->mode == EDIT_HEX)
+            {
+                bufferPosition = StringCopy(bufferPosition, Str_HexPrefix);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            break;
+        case VAL_SPECIES:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 140;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gSpeciesNames[sDebugPkmCreatorData.data[index]], x, y, 0, NULL);
+            break;
+        case VAL_LEVEL:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 140;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_EXP], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_EXP].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            break;
+        case VAL_TID:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 140;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_SID], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_SID].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            x = 180;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, GenderIndexes[sDebugPkmCreatorData.data[VAL_OT_GENDER]], x, y, 0, NULL);
+            break;
+        case VAL_PID:
+            ConvertUIntToHexStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            bufferPosition = StringCopy(bufferPosition, Str_HexPrefix);
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 160;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gNatureNamePointers[sDebugPkmCreatorData.data[8]], x, y, 0, NULL);
+            x = 208;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, GenderIndexes[sDebugPkmCreatorData.data[VAL_PKM_GENDER]], x, y, 0, NULL);
+            x = 214;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, IsShinyIndex[sDebugPkmCreatorData.data[VAL_IS_SHINY]], x, y, 0, NULL);
+            break;
+        case VAL_OT_GENDER:
+        case VAL_PKM_GENDER:
+            StringCopy(gStringVar1, GenderIndexes[sDebugPkmCreatorData.data[index]]);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            break;
+        case VAL_GAME:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 130;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gText_ThreeDashes, x, y, 0, NULL);
+            break;
+        case VAL_ITEM:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 145;
+            CopyItemName(sDebugPkmCreatorData.data[index], gStringVar1);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar1, x, y, 0, NULL);
+            break;
+        case VAL_ABILITY:
+            StringCopy(gStringVar1, gAbilityNames[GetAbilityBySpecies(sDebugPkmCreatorData.data[0], sDebugPkmCreatorData.data[index])]);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            break;
+        case VAL_METLOCATATION:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 130;
+            GetMapName_HandleVersion(gStringVar1, sDebugPkmCreatorData.data[index], sDebugPkmCreatorData.data[13]);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar1, x, y, 0, NULL);
+            break;
+        case VAL_BALL:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 130;
+            CopyItemName(sDebugPkmCreatorData.data[index], gStringVar1);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar1, x, y, 0, NULL);
+            break;
+        case VAL_STATUS:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 130;
+            StringCopy(gStringVar1, StatusIndexes[sDebugPkmCreatorData.data[index]]);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar1, x, y, 0, NULL);
+            break;			
+        case VAL_MOVE_1 ... VAL_MOVE_4:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                *bufferPosition = CHAR_SPACE;
+                bufferPosition++;
+                *bufferPosition = CHAR_1 + (index - 66);
+                bufferPosition++;
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 120;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[70 + (index - 66)], STR_CONV_MODE_LEADING_ZEROS, 2);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            x = 136;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[74 + (index - 66)], STR_CONV_MODE_LEADING_ZEROS, 1);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            x = 144;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gMoveNames[sDebugPkmCreatorData.data[index]], x, y, 0, NULL);
+            break;
+        case VAL_PKRUS_STRAIN:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 140;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_PKRUS_DAYS_DEF], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_PKRUS_DAYS_DEF].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            x = 180;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_PKRUS_DAYS_LEFT], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_PKRUS_DAYS_LEFT].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            break;
+        case VAL_HP_IV ... VAL_SPDEF_IV:
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            if (data->text != NULL)
+            {
+                bufferPosition = StringCopy(bufferPosition, data->text);
+                bufferPosition = StringCopy(bufferPosition, Str_Spacer1);
+            }
+            *gStringVar3 = EOS;
+            StringExpandPlaceholders(bufferPosition, Str_StringVars);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+
+            x = 136;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index + 6], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_HP_MAX].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            x = 172;
+            ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[index - 6], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_HP_MAX].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            if (index == VAL_HP_IV)
+            {
+                x = 172;
+                ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_HP_CURRENT], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_HP_MAX].digitCount);
+                AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+                x = 208;
+                ConvertIntToDecimalStringN(gStringVar1, sDebugPkmCreatorData.data[VAL_HP_MAX], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_HP_MAX].digitCount);
+                AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar1, x, y, 0, NULL);
+            }
+            break;
+        }
+        x = 0;
+        y+= 16;
+        /* TODO: Add non-default cases:
+            * PID (is shiny)
+            * Status (sleep/toxic counter)
+            * Language (language name)
+        */
+    }
+}
+
+static void DebugPkmCreator_EditModeRedraw(u32 digit, u8 editIndex)
+{
+    u32 x = 100;
+    u32 y = sDebugPkmCreatorData.selectedOption * 2 * 8 + 16;
+    u32 i = 0;
+    u8* bufferPosition = gStringVar2;
+    const u8* page = DebugPkmCreator_Pages[sDebugPkmCreatorData.currentPage];
+    const struct EditPokemonStruct* data;
+    u8 index;
+    u32 digitToHighlight;
+
+    if (editIndex != 0 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 1] != 0xFF)
+    {
+        index = DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 1];
+        x += 5 * 8 * editIndex;
+    }
+    else
+        index = page[sDebugPkmCreatorData.selectedOption];
+
+    data = &DebugPkmCreator_Options[index];
+
+    switch (index)
+    {
+    default:
+        switch (data->mode)
+        {
+        case EDIT_NORMAL:
+        default:
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+            ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            break;
+        case EDIT_HEX:
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+            ConvertUIntToHexStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+            bufferPosition = StringCopy(bufferPosition, Str_CursorColor);
+            bufferPosition = StringCopy(bufferPosition, Str_HexPrefix);
+            break;
+        case EDIT_NULL:
+            return; // Haha, don't even make the effort...
+        case EDIT_BOOL:
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 24, 16);
+            bufferPosition = StringCopy(bufferPosition, Str_Cursor2Color);
+            bufferPosition = StringCopy(bufferPosition, DebugPkmCreator_editingVal[editIndex] ? Str_On : Str_Off);
+            *bufferPosition = EOS;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            return;
+        case EDIT_STRING:
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+            StringCopyN(gStringVar1, DebugPkmCreator_NameBuffer, data->digitCount);
+            break;
+        }
+        break;
+    case VAL_SPECIES:
+        // Same as the default case, except we draw more data here
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 140;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 72, 16);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gSpeciesNames[DebugPkmCreator_editingVal[editIndex]], x, y, 0, NULL);
+            x = 100; // Reset for the actual species number
+        }
+        break;
+    case VAL_LEVEL:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            //u32 newExp = gExperienceTables[gSpeciesInfo[sDebugPkmCreatorData.data[VAL_SPECIES]].growthRate][DebugPkmCreator_editingVal[editIndex]];
+            x = 140;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            ConvertIntToDecimalStringN(gStringVar2, sDebugPkmCreatorData.data[VAL_EXP], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_EXP].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_TID:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 140;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            ConvertIntToDecimalStringN(gStringVar2, sDebugPkmCreatorData.data[VAL_SID], STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_SID].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 180;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, GenderIndexes[sDebugPkmCreatorData.data[VAL_OT_GENDER]], x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_PID:
+        if (editIndex == 0) {
+            u32 pid = DebugPkmCreator_editingVal[editIndex];
+            u16 nature = GetNatureFromPersonality(pid);
+            u8 gender = GetGenderFromSpeciesAndPersonality(sDebugPkmCreatorData.data[VAL_SPECIES], pid);
+            u8 isSihny = IsShinyOtIdPersonality(sDebugPkmCreatorData.data[VAL_OT], pid);
+            if (gender == MON_FEMALE) 
+                gender = 1;
+            else if (gender == MON_GENDERLESS) 
+                gender = 2;
+            x = 160;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gNatureNamePointers[nature], x, y, 0, NULL);
+            x = 208;
+            StringCopy(gStringVar2, GenderIndexes[gender]);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+            x = 214;
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, IsShinyIndex[isSihny], x, y, 0, NULL);
+            x = 100;
+        }
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 60, 16);
+        ConvertUIntToHexStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        bufferPosition = StringCopy(bufferPosition, Str_CursorColor);
+        bufferPosition = StringCopy(bufferPosition, Str_HexPrefix);
+        break;
+    case VAL_OT_GENDER:
+    case VAL_PKM_GENDER:
+        if (editIndex != 0 && page[sDebugPkmCreatorData.selectedOption] == 0)
+            x = 204;
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 8, 16);
+        bufferPosition = StringCopy(bufferPosition, Str_Cursor2Color);
+        bufferPosition = StringCopy(bufferPosition, GenderIndexes[DebugPkmCreator_editingVal[editIndex]]);
+        *bufferPosition = EOS;
+        AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+        return;
+    case VAL_GAME:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 130;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gText_ThreeDashes, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_ITEM:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 145;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            CopyItemName(DebugPkmCreator_editingVal[editIndex], gStringVar2);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar2, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_ABILITY:
+        if (editIndex != 0 && page[sDebugPkmCreatorData.selectedOption] == 0)
+            x = 204;
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+        bufferPosition = StringCopy(bufferPosition, Str_Cursor2Color);
+        bufferPosition = StringCopy(bufferPosition, gAbilityNames[GetAbilityBySpecies(sDebugPkmCreatorData.data[0], DebugPkmCreator_editingVal[editIndex])]);
+        *bufferPosition = EOS;
+        AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+        return;
+    case VAL_METLOCATATION:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 130;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            GetMapName_HandleVersion(gStringVar2, DebugPkmCreator_editingVal[editIndex], sDebugPkmCreatorData.data[13]);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar2, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_BALL:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 130;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            CopyItemName(DebugPkmCreator_editingVal[editIndex], gStringVar2);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar2, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_STATUS:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 130;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            CopyItemName(DebugPkmCreator_editingVal[editIndex], gStringVar2);
+            StringCopy(gStringVar2, StatusIndexes[DebugPkmCreator_editingVal[editIndex]]);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gStringVar2, x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_HP_EV ... VAL_SPDEF_EV:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        x = 136;
+        break;
+    case VAL_HP_CURRENT:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        x = 172;
+        break;
+    case VAL_MOVE_1 ... VAL_MOVE_4:
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6 - 4, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        if (editIndex == 0)
+        {
+            x = 144;
+            // TODO: Fill all the way to the end?
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 120, 16);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, 1, gMoveNames[DebugPkmCreator_editingVal[editIndex]], x, y, 0, NULL);
+            x = 100;
+        }
+        break;
+    case VAL_MOVE_1_PP ... VAL_MOVE_4_PP:
+        x = 120;
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        break;
+    case VAL_MOVE_1_PPUP ... VAL_MOVE_4_PPUP:
+        if (TRUE)
+        {
+            u16 move = sDebugPkmCreatorData.data[index - 8];
+            u8 basePP = gBattleMoves[move].pp;
+            basePP = basePP + ((basePP * 20 * DebugPkmCreator_editingVal[editIndex]) / 100);
+
+            x = 120;
+            FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, DebugPkmCreator_Options[VAL_MOVE_1_PP].digitCount * 6, 16);
+            ConvertIntToDecimalStringN(gStringVar2, basePP, STR_CONV_MODE_LEADING_ZEROS, DebugPkmCreator_Options[VAL_MOVE_1_PP].digitCount);
+            AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+        }
+        x = 136;
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        ConvertIntToDecimalStringN(gStringVar1, DebugPkmCreator_editingVal[editIndex], STR_CONV_MODE_LEADING_ZEROS, data->digitCount);
+        break;
+    }
+
+    bufferPosition = StringCopy(bufferPosition, Str_CursorColor);
+    digitToHighlight = data->mode == EDIT_STRING ? digit : data->digitCount - digit - 1;
+    for (i = 0; i < data->digitCount; i++)
+    {
+        if (i == digitToHighlight)
+            bufferPosition = StringCopy(bufferPosition, Str_Cursor2Color);
+        *bufferPosition = gStringVar1[i];
+        bufferPosition++;
+        if (i == digitToHighlight)
+            bufferPosition = StringCopy(bufferPosition, Str_CursorColorOff);
+    }
+    *bufferPosition = EOS;
+    AddTextPrinterParameterized(sDebugPkmCreatorData.menuWindowId, FONT_NARROW, gStringVar2, x, y, 0, NULL);
+    /* TODO Re-print the following data once edited:
+        * PID (is shiny)
+        * Status (sleep/toxic counter)
+        * Language (language name)
+    */
+}
+
+
+
+static void DebugPkmCreator_ProcessInput(u8 taskid)
+{
+    u16 keys = gMain.newKeys;
+    struct Task* task = &gTasks[taskid];
+    struct Pokemon* mons;
+
+    if (keys & DPAD_LEFT) // Switch Pages
+    {
+        if (sDebugPkmCreatorData.currentPage > 0)
+            sDebugPkmCreatorData.currentPage--;
+        else
+            sDebugPkmCreatorData.currentPage = PAGE_COUNT;
+        FillWindowPixelBuffer(sDebugPkmCreatorData.menuWindowId, 0x11);
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & DPAD_RIGHT) // Switch Pages
+    {
+        if (sDebugPkmCreatorData.currentPage < PAGE_COUNT)
+            sDebugPkmCreatorData.currentPage++;
+        else
+            sDebugPkmCreatorData.currentPage = 0;
+        FillWindowPixelBuffer(sDebugPkmCreatorData.menuWindowId, 0x11);
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & DPAD_UP) // Switch Entry
+    {
+        if (sDebugPkmCreatorData.selectedOption > 0)
+            sDebugPkmCreatorData.selectedOption--;
+        else
+            sDebugPkmCreatorData.selectedOption = 5;
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & DPAD_DOWN) // Switch Entry
+    {
+        if (sDebugPkmCreatorData.selectedOption < 5)
+            sDebugPkmCreatorData.selectedOption++;
+        else
+            sDebugPkmCreatorData.selectedOption = 0;
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & L_BUTTON) // Switch Pokemon e.g. in Box or Party (not used on ADD)
+    {
+        // This check is much simpler than the one below it...
+        if (sDebugPkmCreatorData.index <= 0) return;
+        sDebugPkmCreatorData.index--;
+        switch (sDebugPkmCreatorData.mode)
+        {
+        case 2:
+            // We can technically select slot 404 of box 1 (actually box 13 slot 14) but it's still valid behavior provided the max index was set properly above.
+            mons = (struct Pokemon*) &gPokemonStoragePtr->boxes[0][sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct BoxPokemon));
+            CalculateMonStats(&sDebugPkmCreatorData.mon);
+            break;
+        case 1:
+        case 5:
+            mons = &gPlayerParty[sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+            break;
+        case 3:
+        case 4:
+        case 10:
+            mons = &gEnemyParty[sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+            break;
+        default:
+            break;
+        }
+        DebugPkmCreator_PopulateDataStruct();
+        FillWindowPixelBuffer(sDebugPkmCreatorData.menuWindowId, 0x11);
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & R_BUTTON) // Switch Pokemon e.g. in Box or Party (not used on ADD)
+    {
+        u32 max_index;
+        switch (sDebugPkmCreatorData.mode)
+        {
+        case 0:
+        case 6 ... 8:
+        default:
+            return;
+        case 1:
+        case 3 ... 5:
+        case 10:
+            max_index = PARTY_SIZE;
+            break;
+        case 2:
+            max_index = TOTAL_BOXES_COUNT * IN_BOX_COUNT;
+            break;
+        }
+        if (sDebugPkmCreatorData.index >= max_index - 1) return;
+        sDebugPkmCreatorData.index++;
+        switch (sDebugPkmCreatorData.mode)
+        {
+        case 2:
+            mons = (struct Pokemon*) &gPokemonStoragePtr->boxes[0][sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct BoxPokemon));
+            CalculateMonStats(&sDebugPkmCreatorData.mon);
+            break;
+        case 1:
+        case 5:
+            mons = &gPlayerParty[sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+            break;
+        case 3:
+        case 4:
+        case 10:
+            mons = &gEnemyParty[sDebugPkmCreatorData.index];
+            sDebugPkmCreatorData.monBeingEdited = mons;
+            CopyMon(&sDebugPkmCreatorData.mon, mons, sizeof(struct Pokemon));
+            break;
+        }
+        DebugPkmCreator_PopulateDataStruct();
+        FillWindowPixelBuffer(sDebugPkmCreatorData.menuWindowId, 0x11);
+        DebugPkmCreator_Redraw();
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & B_BUTTON) // Close window
+    {
+        ClearStdWindowAndFrame(sDebugPkmCreatorData.headerWindowId, TRUE);
+        RemoveWindow(sDebugPkmCreatorData.headerWindowId);
+        ClearStdWindowAndFrame(sDebugPkmCreatorData.menuWindowId, TRUE);
+        RemoveWindow(sDebugPkmCreatorData.menuWindowId);
+        DestroyTask(taskid);
+        
+        if (sDebugPkmCreatorData.mode == 9 || sDebugPkmCreatorData.mode == 10)
+            Debug_ReShowBattleDebugMenu();
+        else
+        {
+            ScriptContext_Enable();
+            PlaySE(SE_SELECT);
+        }
+        return;
+    }
+    if (keys & SELECT_BUTTON) // TODO: Re-randomize the PID and IVs, or if OT is selected, toggle OT gender
+    {
+        return;
+    }
+    if (keys & A_BUTTON) // Enter Edit Mode
+    {
+        u32 i;
+        u8 index = DebugPkmCreator_Pages[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption];
+        if (DebugPkmCreator_Options[index].mode != EDIT_NULL && DebugPkmCreator_Options[index].mode != EDIT_READONLY)
+        {
+            DebugPkmCreator_editingVal[0] = sDebugPkmCreatorData.data[index];
+            if (DebugPkmCreator_Options[index].mode == EDIT_STRING)
+            {
+                StringCopyN(DebugPkmCreator_NameBuffer, (u8*) DebugPkmCreator_editingVal[0], 16);
+                DebugPkmCreator_NameBuffer[DebugPkmCreator_Options[index].digitCount] = EOS;
+            }
+            else
+            {
+                for (i = 1; i < 4; i++)
+                {
+                    if (DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][i - 1] == 0xFF) 
+                        break;
+                    DebugPkmCreator_editingVal[i] = sDebugPkmCreatorData.data[DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][i - 1]];
+                }
+            }
+            task->data[0] = 0;
+            task->data[1] = 0;
+            DebugPkmCreator_EditModeRedraw(task->data[0], task->data[1]);
+            task->func = DebugPkmCreator_EditModeProcessInput;
+            PlaySE(SE_SELECT);
+        }
+        return;
+    }
+    if (keys & START_BUTTON) // Confirm changes and add/edit Pokemon
+    {
+        DebugPkmCreator_SetMonData();
+        // TODO: Add a confirmation prompt
+        if (DebugPkmCreator_GiveToPlayer() != MON_CANT_GIVE)
+            PlaySE(SE_EXP_MAX);
+        else
+            PlaySE(SE_BOO);
+
+        ClearStdWindowAndFrame(sDebugPkmCreatorData.headerWindowId, TRUE);
+        RemoveWindow(sDebugPkmCreatorData.headerWindowId);
+        ClearStdWindowAndFrame(sDebugPkmCreatorData.menuWindowId, TRUE);
+        RemoveWindow(sDebugPkmCreatorData.menuWindowId);
+        DestroyTask(taskid);
+        if (sDebugPkmCreatorData.mode == 9 || sDebugPkmCreatorData.mode == 10)
+            Debug_ReShowBattleDebugMenu();
+        else
+            ScriptContext_Enable();
+        return;
+    }
+}
+
+static const u32 powersOf10[10] = {
+    1,
+    10,
+    100,
+    1000,
+    10000,
+    100000,
+    1000000,
+    10000000,
+    100000000,
+    1000000000,
+};
+
+static void DebugPkmCreator_EditModeProcessInput(u8 taskid)
+{
+    u16 keys = gMain.newKeys;
+    u16 heldKeys = gMain.newAndRepeatedKeys;
+    struct Task* task = &gTasks[taskid];
+    u32 i, j, min, max, index, indexBeingEdited;
+    u32 z = 0;
+
+    u16 digit = task->data[0];
+    u16 editIndex = task->data[1];
+
+    u32 x = 100;
+    u32 y = sDebugPkmCreatorData.selectedOption * 2 * 8 + 16;
+
+    const struct EditPokemonStruct* data;
+    const u8* page = DebugPkmCreator_Pages[sDebugPkmCreatorData.currentPage];
+
+    if (editIndex != 0 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 1] != 0xFF) 
+        index = DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 1];
+    else
+        index = page[sDebugPkmCreatorData.selectedOption];
+
+    data = &DebugPkmCreator_Options[index];
+
+    switch (index)
+    {
+    default:
+        min = data->min;
+        max = data->max;
+        break;
+    }
+
+    if (keys & B_BUTTON) // Leave Edit Mode
+    {
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, 124, 16);
+        DebugPkmCreator_Redraw();
+        task->func = DebugPkmCreator_ProcessInput;
+        PlaySE(SE_SELECT);
+        return;
+    }
+
+    if (keys & (A_BUTTON | START_BUTTON)) // Confirm current changes
+    {
+        if (data->mode == EDIT_STRING)
+            StringCopyN((u8*) sDebugPkmCreatorData.data[index], DebugPkmCreator_NameBuffer, data->digitCount);
+        else
+        {
+            for (i = 0; i < 4; i++)
+            {
+                if (i != 0)
+                    indexBeingEdited = DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][i - 1];
+                else 
+                    indexBeingEdited = index;
+                
+                // Skip if: no entry, no value change or readonly value
+                if (indexBeingEdited == 0xFF)
+                    continue;
+                if (sDebugPkmCreatorData.data[indexBeingEdited] == DebugPkmCreator_editingVal[i])
+                    continue;
+                data = &DebugPkmCreator_Options[indexBeingEdited];
+                if (data->mode == EDIT_READONLY)
+                    continue;
+
+                sDebugPkmCreatorData.data[indexBeingEdited] = DebugPkmCreator_editingVal[i];
+                switch (indexBeingEdited)
+                {
+                default:
+                    DebugPkmCreator_SetMonData();
+                    DebugPkmCreator_PopulateDataStruct();
+                    break;
+                case VAL_SPECIES:
+                    DebugPkmCreator_SetMonData();
+                    SetMonData(&sDebugPkmCreatorData.mon, data->SetMonDataParam, &DebugPkmCreator_editingVal[i]);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_NICKNAME, gSpeciesNames[DebugPkmCreator_editingVal[i]]);
+                    // Clear moves
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_MOVE1, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_MOVE2, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_MOVE3, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_MOVE4, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_PP1, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_PP2, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_PP3, &z);
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_PP4, &z);
+                    GiveMonInitialMoveset(&sDebugPkmCreatorData.mon);
+                    // preserve level
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[DebugPkmCreator_editingVal[i]].growthRate][sDebugPkmCreatorData.data[15]]);
+                    CalculateMonStats(&sDebugPkmCreatorData.mon);
+                    // preserve sanity bit
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_SANITY_HAS_SPECIES, &sDebugPkmCreatorData.data[11]);
+                    DebugPkmCreator_PopulateDataStruct();
+                    break;
+                case VAL_PID ... VAL_SID:
+                    DebugPkmCreator_Init_SetNewMonData(FALSE);
+                    DebugPkmCreator_PopulateDataStruct();
+                    break;
+                case VAL_LEVEL:
+                    SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_EXP, &gExperienceTables[gSpeciesInfo[sDebugPkmCreatorData.data[VAL_SPECIES]].growthRate][sDebugPkmCreatorData.data[VAL_LEVEL]]);
+                    CalculateMonStats(&sDebugPkmCreatorData.mon);
+                    DebugPkmCreator_PopulateDataStruct();
+                    DebugPkmCreator_editingVal[0] = sDebugPkmCreatorData.data[VAL_LEVEL];
+                    DebugPkmCreator_editingVal[1] = sDebugPkmCreatorData.data[VAL_EXP];
+                    break;
+                case VAL_EXP:
+                    SetMonData(&sDebugPkmCreatorData.mon, data->SetMonDataParam, &DebugPkmCreator_editingVal[i]);
+                    CalculateMonStats(&sDebugPkmCreatorData.mon);
+                    DebugPkmCreator_PopulateDataStruct();
+                    break;
+                case VAL_HP_IV ... VAL_SPDEF_EV:
+                    if (indexBeingEdited == VAL_HP_IV || indexBeingEdited == VAL_HP_EV)
+                    {
+                        u16 maxHp;
+                        SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_HP_IV, &DebugPkmCreator_editingVal[0]);
+                        SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_HP_EV, &DebugPkmCreator_editingVal[1]);
+                        CalculateMonStats(&sDebugPkmCreatorData.mon);
+                        maxHp = GetMonData(&sDebugPkmCreatorData.mon, MON_DATA_MAX_HP, NULL);
+                        sDebugPkmCreatorData.data[VAL_HP_CURRENT] = maxHp;
+                        SetMonData(&sDebugPkmCreatorData.mon, MON_DATA_HP, &maxHp);
+                        DebugPkmCreator_editingVal[2] = maxHp;
+                        DebugPkmCreator_PopulateDataStruct();
+                        i = 4;
+                        break;
+                    }
+                    
+                    SetMonData(&sDebugPkmCreatorData.mon, data->SetMonDataParam, &DebugPkmCreator_editingVal[i]);
+                    CalculateMonStats(&sDebugPkmCreatorData.mon);
+                    DebugPkmCreator_PopulateDataStruct();
+                    break;
+                }
+            }
+        }
+        FillWindowPixelRect(sDebugPkmCreatorData.menuWindowId, 0x11, x, y, data->digitCount * 6, 16);
+        DebugPkmCreator_Redraw();
+        task->func = DebugPkmCreator_ProcessInput;
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (heldKeys & DPAD_UP) // Change selected value
+    {
+        if (index == 1) // PID does have a min/max, but they cover the entire 32-bit value range.
+        {
+            DebugPkmCreator_editingVal[editIndex] += (1 << (4 * digit));
+            DebugPkmCreator_EditModeRedraw(digit, editIndex);
+            PlaySE(SE_SELECT);
+            return;
+        }
+        switch (data->mode)
+        {
+        case EDIT_NORMAL:
+        default:
+            if (DebugPkmCreator_editingVal[editIndex] + powersOf10[digit] > max)
+                DebugPkmCreator_editingVal[editIndex] = data->min;
+            else
+                DebugPkmCreator_editingVal[editIndex] += powersOf10[digit];
+            break;
+        case EDIT_NULL:
+        case EDIT_READONLY:
+            return;
+        case EDIT_BOOL:
+            if (DebugPkmCreator_editingVal[editIndex]) return;
+            DebugPkmCreator_editingVal[editIndex] = TRUE;
+            break;
+        case EDIT_HEX:
+            if (DebugPkmCreator_editingVal[editIndex] + (1 << (4 * digit)) > max)
+                DebugPkmCreator_editingVal[editIndex] = data->min;
+            else
+                DebugPkmCreator_editingVal[editIndex] += (1 << (4 * digit));
+            break;
+        case EDIT_STRING:
+            DebugPkmCreator_NameBuffer[digit]++;
+            DebugPkmCreator_NameBuffer[digit] &= 0xFF;
+            if (DebugPkmCreator_NameBuffer[digit] >= CHAR_DYNAMIC)
+                DebugPkmCreator_NameBuffer[digit] = EOS;
+            else if (DebugPkmCreator_NameBuffer[digit] >= CHAR_DYNAMIC && DebugPkmCreator_NameBuffer[digit] < EOS)
+                DebugPkmCreator_NameBuffer[digit] = 0;
+            break;
+        }
+        DebugPkmCreator_EditModeRedraw(digit, editIndex);
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (heldKeys & DPAD_DOWN) // Change selected value
+    {
+        if (index == 1)
+        {
+            DebugPkmCreator_editingVal[editIndex] -= (1 << (4 * digit));
+            DebugPkmCreator_EditModeRedraw(digit, editIndex);
+            PlaySE(SE_SELECT);
+            return;
+        }
+        switch (data->mode)
+        {
+        case EDIT_NORMAL:
+        default:
+            if ((s32) (DebugPkmCreator_editingVal[editIndex] - powersOf10[digit]) < (s32) min)
+                DebugPkmCreator_editingVal[editIndex] = data->max;
+            else
+                DebugPkmCreator_editingVal[editIndex] -= powersOf10[digit];
+            break;
+        case EDIT_NULL:
+        case EDIT_READONLY:
+            return;
+        case EDIT_BOOL:
+            if (!DebugPkmCreator_editingVal[editIndex]) return;
+            DebugPkmCreator_editingVal[editIndex] = FALSE;
+            break;
+        case EDIT_HEX:
+            if ((s32) (DebugPkmCreator_editingVal[editIndex] - (1 << (4 * digit))) < (s32) min)
+                DebugPkmCreator_editingVal[editIndex] = data->max;
+            else
+                DebugPkmCreator_editingVal[editIndex] -= (1 << (4 * digit));
+            break;
+        case EDIT_STRING:
+            DebugPkmCreator_NameBuffer[digit]--;
+            DebugPkmCreator_NameBuffer[digit] &= 0xFF;
+            if (DebugPkmCreator_NameBuffer[digit] >= CHAR_DYNAMIC && DebugPkmCreator_NameBuffer[digit] < EOS)
+                DebugPkmCreator_NameBuffer[digit] = CHAR_DYNAMIC - 1;
+            break;
+        }
+        DebugPkmCreator_EditModeRedraw(digit, editIndex);
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & DPAD_LEFT) // Change selected digit
+    {
+        if (data->mode == EDIT_STRING)
+        {
+            if ((s16) (digit - 1) < 0)
+            {
+                if ((editIndex != 0 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 2] != 0xFF) || editIndex == 1)
+                {
+                    DebugPkmCreator_EditModeRedraw(data->digitCount, editIndex);
+                    digit = DebugPkmCreator_Options[DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex]].digitCount - 1;
+                    editIndex--;
+                }
+                else
+                    return;
+            }
+            else 
+                digit--;
+        }
+        else
+        {
+            if (digit >= data->digitCount - 1)
+            {
+                if ((editIndex != 0 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex - 2] != 0xFF) || editIndex == 1)
+                {
+                    DebugPkmCreator_EditModeRedraw(data->digitCount, editIndex);
+                    digit = 0;
+                    editIndex--;
+                }
+                else 
+                    return;
+            }
+            else 
+                digit++;
+        }
+        DebugPkmCreator_EditModeRedraw(digit, editIndex);
+        task->data[0] = digit;
+        task->data[1] = editIndex;
+        PlaySE(SE_SELECT);
+        return;
+    }
+    if (keys & DPAD_RIGHT) // Change selected digit
+    {
+        if (data->mode == EDIT_STRING)
+        {
+            if (digit >= data->digitCount - 1)
+            {
+                if (editIndex + 1 < 4 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex] != 0xFF)
+                {
+                    DebugPkmCreator_EditModeRedraw(data->digitCount, editIndex);
+                    digit = 0;
+                    editIndex++;
+                }
+                else
+                    return;
+            }
+            else
+                digit++;
+        }
+        else 
+        {
+            if ((s16) (digit - 1) < 0) 
+            {
+                if (editIndex + 1 < 4 && DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex] != 0xFF && DebugPkmCreator_Options[DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex]].mode != EDIT_READONLY)
+                {
+                    DebugPkmCreator_EditModeRedraw(data->digitCount, editIndex);
+                    digit = DebugPkmCreator_Options[DebugPkmCreator_AltIndexes[sDebugPkmCreatorData.currentPage][sDebugPkmCreatorData.selectedOption][editIndex]].digitCount - 1;
+                    editIndex++;
+                }
+                else
+                    return;
+            }
+            else
+                digit--;
+        }
+        DebugPkmCreator_EditModeRedraw(digit, editIndex);
+        task->data[0] = digit;
+        task->data[1] = editIndex;
+        PlaySE(SE_SELECT);
+        return;
+    }
+    // TODO: Select resets the value to default
+}
+
+// This is basically a copy of GiveMonToPlayer, except without setting the OT details to the player's.
+static u8 DebugPkmCreator_GiveToPlayer(void)
+{
+    u32 i;
+    struct Pokemon* mon = &sDebugPkmCreatorData.mon;
+    switch (sDebugPkmCreatorData.mode)
+    {
+    case 0:
+        for (i = 0; i < PARTY_SIZE; i++)
+        {
+            if (GetMonData(&gPlayerParty[i], MON_DATA_SPECIES, NULL) == 0)
+                break;
+        }
+
+        if (i >= PARTY_SIZE)
+            return CopyMonToPC(mon);
+
+        CopyMon(&gPlayerParty[i], mon, sizeof(*mon));
+        gPlayerPartyCount = i + 1;
+        return MON_GIVEN_TO_PARTY;
+    case 1:
+    case 3 ... 5:
+    case 10:
+        CopyMon(sDebugPkmCreatorData.monBeingEdited, mon, sizeof(struct Pokemon));
+        return MON_GIVEN_TO_PARTY;
+    case 2:
+        CopyMon(sDebugPkmCreatorData.monBeingEdited, mon, sizeof(struct BoxPokemon));
+        return MON_GIVEN_TO_PC;
+    case 6:
+    case 9:
+        for (i = 0; i < PARTY_SIZE; i++)
+        {
+            if (GetMonData(&gEnemyParty[i], MON_DATA_SPECIES, NULL) == SPECIES_NONE)
+                break;
+        }
+
+        if (i >= PARTY_SIZE)
+            return MON_CANT_GIVE;
+
+        CopyMon(&gEnemyParty[i], mon, sizeof(*mon));
+        gEnemyPartyCount = i + 1;
+        return MON_GIVEN_TO_PARTY;
+    case 7:
+    case 8:
+    default:
+        return MON_CANT_GIVE;
+    }
+}
+#endif

--- a/src/event_data.c
+++ b/src/event_data.c
@@ -179,6 +179,14 @@ u16 VarGet(u16 id)
     return *ptr;
 }
 
+u16 VarGetIfExist(u16 id)
+{
+    u16 *ptr = GetVarPointer(id);
+    if (!ptr)
+        return 65535;
+    return *ptr;
+}
+
 bool8 VarSet(u16 id, u16 value)
 {
     u16 *ptr = GetVarPointer(id);
@@ -208,6 +216,14 @@ u8 FlagSet(u16 id)
     u8 *ptr = GetFlagPointer(id);
     if (ptr)
         *ptr |= 1 << (id & 7);
+    return 0;
+}
+
+u8 FlagToggle(u16 id)
+{
+    u8 *ptr = GetFlagPointer(id);
+    if (ptr)
+        *ptr ^= 1 << (id & 7);
     return 0;
 }
 

--- a/src/event_object_movement.c
+++ b/src/event_object_movement.c
@@ -2,6 +2,7 @@
 #include "malloc.h"
 #include "battle_pyramid.h"
 #include "berry.h"
+#include "debug.h"
 #include "decoration.h"
 #include "event_data.h"
 #include "event_object_movement.h"
@@ -4647,6 +4648,10 @@ static u8 GetCollisionInDirection(struct ObjectEvent *objectEvent, u8 direction)
 u8 GetCollisionAtCoords(struct ObjectEvent *objectEvent, s16 x, s16 y, u32 dir)
 {
     u8 direction = dir;
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    if (FlagGet(FLAG_SYS_NO_COLLISION))
+        return COLLISION_NONE;
+#endif
     if (IsCoordOutsideObjectEventMovementRange(objectEvent, x, y))
         return COLLISION_OUTSIDE_RANGE;
     else if (MapGridGetCollisionAt(x, y) || GetMapBorderIdAt(x, y) == CONNECTION_INVALID || IsMetatileDirectionallyImpassable(objectEvent, x, y, direction))

--- a/src/field_control_avatar.c
+++ b/src/field_control_avatar.c
@@ -3,6 +3,7 @@
 #include "bike.h"
 #include "coord_event_weather.h"
 #include "daycare.h"
+#include "debug.h"
 #include "faraway_island.h"
 #include "event_data.h"
 #include "event_object_movement.h"
@@ -129,6 +130,14 @@ void FieldGetPlayerInput(struct FieldInput *input, u16 newKeys, u16 heldKeys)
         input->dpadDirection = DIR_WEST;
     else if (heldKeys & DPAD_RIGHT)
         input->dpadDirection = DIR_EAST;
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE && TX_DEBUG_SYSTEM_IN_MENU == FALSE
+    if ((heldKeys & TX_DEBUG_SYSTEM_HELD_KEYS) && input->TX_DEBUG_SYSTEM_TRIGGER_EVENT)
+    {
+        input->input_field_1_2 = TRUE;
+        input->TX_DEBUG_SYSTEM_TRIGGER_EVENT = FALSE;
+    }
+#endif
 }
 
 int ProcessPlayerFieldInput(struct FieldInput *input)
@@ -187,6 +196,16 @@ int ProcessPlayerFieldInput(struct FieldInput *input)
     }
     if (input->pressedSelectButton && UseRegisteredKeyItemOnField() == TRUE)
         return TRUE;
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE && TX_DEBUG_SYSTEM_IN_MENU == FALSE
+    if (input->input_field_1_2)
+    {
+        PlaySE(SE_WIN_OPEN);
+        FreezeObjectEvents();
+        Debug_ShowMainMenu();
+        return TRUE;
+    }
+#endif
 
     return FALSE;
 }
@@ -667,6 +686,11 @@ void RestartWildEncounterImmunitySteps(void)
 
 static bool8 CheckStandardWildEncounter(u16 metatileBehavior)
 {
+    #if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    if (FlagGet(FLAG_SYS_NO_ENCOUNTER))
+        return FALSE;
+    #endif
+
     if (sWildEncounterImmunitySteps < 4)
     {
         sWildEncounterImmunitySteps++;

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -8,6 +8,7 @@
 #include "bike.h"
 #include "coins.h"
 #include "data.h"
+#include "debug.h"
 #include "event_data.h"
 #include "event_object_lock.h"
 #include "event_object_movement.h"
@@ -941,6 +942,14 @@ void ItemUseOutOfBattle_EvolutionStone(u8 taskId)
 
 void ItemUseInBattle_PokeBall(u8 taskId)
 {
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    if (FlagGet(FLAG_SYS_NO_CATCHING)){
+        static const u8 sText_BallsCannotBeUsed[] = _("Poké Balls cannot be used\nright now!\p");
+        DisplayItemMessage(taskId, 1, sText_BallsCannotBeUsed, CloseItemMessage);
+        return;
+    }
+#endif
+
     if (IsPlayerPartyAndPokemonStorageFull() == FALSE) // have room for mon?
     {
         RemoveBagItem(gSpecialVar_ItemId, 1);

--- a/src/main_menu.c
+++ b/src/main_menu.c
@@ -13,6 +13,7 @@
 #include "international_string_util.h"
 #include "link.h"
 #include "main.h"
+#include "main_menu.h"
 #include "menu.h"
 #include "list_menu.h"
 #include "mystery_event_menu.h"
@@ -224,7 +225,6 @@ static void Task_NewGameBirchSpeech_WaitForWhatsYourNameToPrint(u8);
 static void Task_NewGameBirchSpeech_WaitPressBeforeNameChoice(u8);
 static void Task_NewGameBirchSpeech_StartNamingScreen(u8);
 static void CB2_NewGameBirchSpeech_ReturnFromNamingScreen(void);
-static void NewGameBirchSpeech_SetDefaultPlayerName(u8);
 static void Task_NewGameBirchSpeech_CreateNameYesNo(u8);
 static void Task_NewGameBirchSpeech_ProcessNameYesNoMenu(u8);
 void CreateYesNoMenuParameterized(u8, u8, u16, u16, u8, u8);
@@ -2103,7 +2103,7 @@ static s8 NewGameBirchSpeech_ProcessGenderMenuInput(void)
     return Menu_ProcessInputNoWrap();
 }
 
-static void NewGameBirchSpeech_SetDefaultPlayerName(u8 nameId)
+void NewGameBirchSpeech_SetDefaultPlayerName(u8 nameId)
 {
     const u8 *name;
     u8 i;

--- a/src/new_game.c
+++ b/src/new_game.c
@@ -90,7 +90,7 @@ static void InitPlayerTrainerId(void)
 // L=A isnt set here for some reason.
 static void SetDefaultOptions(void)
 {
-    gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_MID;
+    gSaveBlock2Ptr->optionsTextSpeed = OPTIONS_TEXT_SPEED_FAST;
     gSaveBlock2Ptr->optionsWindowFrameType = 0;
     gSaveBlock2Ptr->optionsSound = OPTIONS_SOUND_MONO;
     gSaveBlock2Ptr->optionsBattleStyle = OPTIONS_BATTLE_STYLE_SHIFT;

--- a/src/pokemon.c
+++ b/src/pokemon.c
@@ -70,7 +70,6 @@ static void Task_PlayMapChosenOrBattleBGM(u8 taskId);
 static bool8 ShouldGetStatBadgeBoost(u16 flagId, u8 battlerId);
 static u16 GiveMoveToBoxMon(struct BoxPokemon *boxMon, u16 move);
 static bool8 ShouldSkipFriendshipChange(void);
-static u8 CopyMonToPC(struct Pokemon *mon);
 
 EWRAM_DATA static u8 sLearningMoveTableID = 0;
 EWRAM_DATA u8 gPlayerPartyCount = 0;
@@ -4412,7 +4411,7 @@ u8 GiveMonToPlayer(struct Pokemon *mon)
     return MON_GIVEN_TO_PARTY;
 }
 
-static u8 CopyMonToPC(struct Pokemon *mon)
+u8 CopyMonToPC(struct Pokemon *mon)
 {
     s32 boxNo, boxPos;
 

--- a/src/pokemon_storage_system.c
+++ b/src/pokemon_storage_system.c
@@ -576,7 +576,6 @@ EWRAM_DATA static u8 sMovingMonOrigBoxPos = 0;
 EWRAM_DATA static bool8 sAutoActionOn = 0;
 
 // Main tasks
-static void EnterPokeStorage(u8);
 static void Task_InitPokeStorage(u8);
 static void Task_PlaceMon(u8);
 static void Task_ChangeScreen(u8);
@@ -1660,10 +1659,15 @@ static void FieldTask_ReturnToPcMenu(void)
     MainCallback vblankCb = gMain.vblankCallback;
 
     SetVBlankCallback(NULL);
-    taskId = CreateTask(Task_PCMainMenu, 80);
-    gTasks[taskId].tState = 0;
-    gTasks[taskId].tSelectedOption = sPreviousBoxOption;
-    Task_PCMainMenu(taskId);
+    if (!FlagGet(FLAG_SYS_PC_FROM_DEBUG_MENU)) {
+        taskId = CreateTask(Task_PCMainMenu, 80);
+        gTasks[taskId].tState = 0;
+        gTasks[taskId].tSelectedOption = sPreviousBoxOption;
+        Task_PCMainMenu(taskId);
+    } else {
+        FlagClear(FLAG_SYS_PC_FROM_DEBUG_MENU);
+        ScriptContext_Enable();
+    }
     SetVBlankCallback(vblankCb);
     FadeInFromBlack();
 }
@@ -1994,7 +1998,7 @@ static void CB2_PokeStorage(void)
     BuildOamBuffer();
 }
 
-static void EnterPokeStorage(u8 boxOption)
+void EnterPokeStorage(u8 boxOption)
 {
     ResetTasks();
     sCurrentBoxOption = boxOption;

--- a/src/region_map.c
+++ b/src/region_map.c
@@ -2025,3 +2025,37 @@ static void CB_ExitFlyMap(void)
         break;
     }
 }
+
+u8* GetMapName_HandleVersion(u8* dest, u16 mapsec, u8 version) {
+	switch (version)
+    {
+	default:
+		if ((mapsec & 255) == METLOC_SPECIAL_EGG) {
+			return StringCopy(dest, gRegionMapEntries[214].name);
+		}
+		else if ((mapsec & 255) == METLOC_IN_GAME_TRADE) {
+			return StringCopy(dest, gRegionMapEntries[215].name);
+		}
+		else if ((mapsec & 255) == METLOC_FATEFUL_ENCOUNTER) {
+			return StringCopy(dest, gRegionMapEntries[216].name);
+		}
+		else {
+			return GetMapNameGeneric(dest, mapsec & 255);
+		}
+		// TODO: expand R/S Aqua Hideout placeholder
+	case 1 ... 6: // R/S/E/FR/LG/WB
+		if (mapsec == 253) {
+			return StringCopy(dest, gRegionMapEntries[214].name);
+		}
+		else if (mapsec == 254) {
+			return StringCopy(dest, gRegionMapEntries[215].name);
+		}
+		else if (mapsec == 255) {
+			return StringCopy(dest, gRegionMapEntries[216].name);
+		}
+		else if (mapsec < 213) {
+			return StringCopy(dest, gRegionMapEntries[mapsec].name);
+		}
+		// TODO: expand R/S Aqua Hideout placeholder
+    }
+}

--- a/src/start_menu.c
+++ b/src/start_menu.c
@@ -3,6 +3,7 @@
 #include "battle_pyramid.h"
 #include "battle_pyramid_bag.h"
 #include "bg.h"
+#include "debug.h"
 #include "event_data.h"
 #include "event_object_movement.h"
 #include "event_object_lock.h"
@@ -62,7 +63,8 @@ enum
     MENU_ACTION_PLAYER_LINK,
     MENU_ACTION_REST_FRONTIER,
     MENU_ACTION_RETIRE_FRONTIER,
-    MENU_ACTION_PYRAMID_BAG
+    MENU_ACTION_PYRAMID_BAG,
+    MENU_ACTION_DEBUG,
 };
 
 // Save status
@@ -103,6 +105,7 @@ static bool8 StartMenuSafariZoneRetireCallback(void);
 static bool8 StartMenuLinkModePlayerNameCallback(void);
 static bool8 StartMenuBattlePyramidRetireCallback(void);
 static bool8 StartMenuBattlePyramidBagCallback(void);
+static bool8 StartMenuDebugCallback(void);
 
 // Menu callbacks
 static bool8 SaveStartCallback(void);
@@ -179,6 +182,8 @@ static const struct WindowTemplate sWindowTemplate_PyramidPeak = {
     .baseBlock = 0x8
 };
 
+static const u8 gText_MenuDebug[] = _("DEBUG");
+
 static const struct MenuAction sStartMenuItems[] =
 {
     [MENU_ACTION_POKEDEX]         = {gText_MenuPokedex, {.u8_void = StartMenuPokedexCallback}},
@@ -193,7 +198,8 @@ static const struct MenuAction sStartMenuItems[] =
     [MENU_ACTION_PLAYER_LINK]     = {gText_MenuPlayer,  {.u8_void = StartMenuLinkModePlayerNameCallback}},
     [MENU_ACTION_REST_FRONTIER]   = {gText_MenuRest,    {.u8_void = StartMenuSaveCallback}},
     [MENU_ACTION_RETIRE_FRONTIER] = {gText_MenuRetire,  {.u8_void = StartMenuBattlePyramidRetireCallback}},
-    [MENU_ACTION_PYRAMID_BAG]     = {gText_MenuBag,     {.u8_void = StartMenuBattlePyramidBagCallback}}
+    [MENU_ACTION_PYRAMID_BAG]     = {gText_MenuBag,     {.u8_void = StartMenuBattlePyramidBagCallback}},
+    [MENU_ACTION_DEBUG]           = {gText_MenuDebug,   {.u8_void = StartMenuDebugCallback}}
 };
 
 static const struct BgTemplate sBgTemplates_LinkBattleSave[] =
@@ -237,6 +243,7 @@ static const struct WindowTemplate sSaveInfoWindowTemplate = {
 static void BuildStartMenuActions(void);
 static void AddStartMenuAction(u8 action);
 static void BuildNormalStartMenu(void);
+static void BuildDebugStartMenu(void);
 static void BuildSafariZoneStartMenu(void);
 static void BuildLinkModeStartMenu(void);
 static void BuildUnionRoomStartMenu(void);
@@ -265,6 +272,7 @@ static void CB2_SaveAfterLinkBattle(void);
 static void ShowSaveInfoWindow(void);
 static void RemoveSaveInfoWindow(void);
 static void HideStartMenuWindow(void);
+static void HideStartMenuDebug(void);
 
 void SetDexPokemonPokenavFlags(void) // unused
 {
@@ -303,7 +311,11 @@ static void BuildStartMenuActions(void)
     }
     else
     {
+    #if defined(TX_DEBUG_SYSTEM_ENABLE) && TX_DEBUG_SYSTEM_IN_MENU
+        BuildDebugStartMenu();
+    #else
         BuildNormalStartMenu();
+    #endif
     }
 }
 
@@ -334,6 +346,30 @@ static void BuildNormalStartMenu(void)
     AddStartMenuAction(MENU_ACTION_SAVE);
     AddStartMenuAction(MENU_ACTION_OPTION);
     AddStartMenuAction(MENU_ACTION_EXIT);
+}
+
+static void BuildDebugStartMenu(void)
+{    
+    if (FlagGet(FLAG_SYS_POKEDEX_GET) == TRUE)
+    {
+        AddStartMenuAction(MENU_ACTION_POKEDEX);
+    }
+    if (FlagGet(FLAG_SYS_POKEMON_GET) == TRUE)
+    {
+        AddStartMenuAction(MENU_ACTION_POKEMON);
+    }
+
+    AddStartMenuAction(MENU_ACTION_BAG);
+
+    if (FlagGet(FLAG_SYS_POKENAV_GET) == TRUE)
+    {
+        AddStartMenuAction(MENU_ACTION_POKENAV);
+    }
+
+    AddStartMenuAction(MENU_ACTION_PLAYER);
+    AddStartMenuAction(MENU_ACTION_SAVE);
+    AddStartMenuAction(MENU_ACTION_OPTION);
+    AddStartMenuAction(MENU_ACTION_DEBUG);
 }
 
 static void BuildSafariZoneStartMenu(void)
@@ -617,6 +653,7 @@ static bool8 HandleStartMenuInput(void)
 
         if (gMenuCallback != StartMenuSaveCallback
             && gMenuCallback != StartMenuExitCallback
+            && gMenuCallback != StartMenuDebugCallback
             && gMenuCallback != StartMenuSafariZoneRetireCallback
             && gMenuCallback != StartMenuBattlePyramidRetireCallback)
         {
@@ -752,6 +789,19 @@ static bool8 StartMenuExitCallback(void)
     return TRUE;
 }
 
+static bool8 StartMenuDebugCallback(void)
+{
+    RemoveExtraStartMenuWindows();
+    HideStartMenuDebug(); // Hide start menu without enabling movement
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    FreezeObjectEvents();
+    Debug_ShowMainMenu();
+#endif
+
+    return TRUE;
+}
+
 static bool8 StartMenuSafariZoneRetireCallback(void)
 {
     RemoveExtraStartMenuWindows();
@@ -759,6 +809,13 @@ static bool8 StartMenuSafariZoneRetireCallback(void)
     SafariZoneRetirePrompt();
 
     return TRUE;
+}
+
+static void HideStartMenuDebug(void)
+{
+    PlaySE(SE_SELECT);
+    ClearStdWindowAndFrame(GetStartMenuWindowId(), TRUE);
+    RemoveStartMenuWindow();
 }
 
 static bool8 StartMenuLinkModePlayerNameCallback(void)

--- a/src/trainer_see.c
+++ b/src/trainer_see.c
@@ -1,5 +1,6 @@
 #include "global.h"
 #include "battle_setup.h"
+#include "debug.h"
 #include "event_data.h"
 #include "event_object_movement.h"
 #include "field_effect.h"
@@ -191,6 +192,11 @@ static const struct SpriteTemplate sSpriteTemplate_HeartIcon =
 bool8 CheckForTrainersWantingBattle(void)
 {
     u8 i;
+
+#if TX_DEBUG_SYSTEM_ENABLE == TRUE
+    if (FlagGet(FLAG_SYS_NO_TRAINER_SEE))
+        return FALSE;
+#endif
 
     gNoOfApproachingTrainers = 0;
     gApproachingTrainerId = 0;

--- a/src/wild_encounter.c
+++ b/src/wild_encounter.c
@@ -965,3 +965,12 @@ static void ApplyCleanseTagEncounterRateMod(u32 *encRate)
     if (GetMonData(&gPlayerParty[0], MON_DATA_HELD_ITEM) == ITEM_CLEANSE_TAG)
         *encRate = *encRate * 2 / 3;
 }
+
+bool8 StandardWildEncounter_Debug(void)
+{
+    u16 headerId = GetCurrentMapWildMonHeaderId();
+    if (TryGenerateWildMon(gWildMonHeaders[headerId].landMonsInfo, WILD_AREA_LAND, 0) != TRUE)
+        return FALSE;
+
+    DoStandardWildBattle_Debug();
+}

--- a/sym_ewram.txt
+++ b/sym_ewram.txt
@@ -149,3 +149,5 @@
 	.include "src/faraway_island.o"
 	.include "src/trainer_hill.o"
 	.include "src/rayquaza_scene.o"
+	.include "src/debug.o"
+	.include "src/debug_pokemon_creator.o"

--- a/tools/mapjson/mapjson.cpp
+++ b/tools/mapjson/mapjson.cpp
@@ -458,12 +458,14 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
     text << "//\n// DO NOT MODIFY THIS FILE! It is auto-generated from data/maps/map_groups.json\n//\n\n";
 
     int group_num = 0;
+    vector<int> map_count_vec; //DEBUG
 
     for (auto &group : groups_data["group_order"].array_items()) {
         string groupName = json_to_string(group);
         text << "// " << groupName << "\n";
         vector<string> map_ids;
-        size_t max_length = 0;
+        size_t max_length = 0; //DEBUG
+        int map_count = 0; //DEBUG
 
         for (auto &map_name : groups_data[groupName].array_items()) {
             string map_filepath = file_dir + json_to_string(map_name) + dir_separator + "map.json";
@@ -475,6 +477,8 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
             map_ids.push_back(id);
             if (id.length() > max_length)
                 max_length = id.length();
+
+            map_count++; //DEBUG
         }
 
         int map_id_num = 0;
@@ -485,9 +489,16 @@ string generate_map_constants_text(string groups_filepath, Json groups_data) {
         text << "\n";
 
         group_num++;
+        map_count_vec.push_back(map_count); //DEBUG
     }
 
     text << "#define MAP_GROUPS_COUNT " << group_num << "\n\n";
+    text << "// static const u8 MAP_GROUP_COUNT[] = {"; //DEBUG
+    for(int i=0; i<group_num; i++){                     //DEBUG
+        text << map_count_vec[i] << ", ";               //DEBUG
+    }                                                   //DEBUG
+    text << "0};\n\n";                                  //DEBUG
+
     text << "#endif // GUARD_CONSTANTS_MAP_GROUPS_H\n";
 
     return text.str();


### PR DESCRIPTION
## What

Develop a debug menu to facilitate navigation and testing of the game. This feature will be crucial as I introduce new elements and seek methods to streamline the development cycle for changes.

This enhancement allows for specific functionalities when the `TX_DEBUG_SYSTEM_ENABLE` Macro is configured to `TRUE`.

* Add any item to your bag
* Fly/Teleport anywhere
* Add/Edit pokemon to your party on-demand (with ability to specify every attribute)
* Ability to toggle walk through walls
* Ability to access PC anywhere
* Debug Battles
* Modify Global Flags
* Test Custom Scripts
* Quick setup game from scratch
* Swap Battle Backgrounds
* Change Music
* Disable Wild Encounters
* Ect...

To access the debug menu currently, hold the `R` button and press `start`.

Follow: https://www.pokecommunity.com/threads/simple-modifications-directory.416647/page-9#post-10220970

I've made necessary adjustments due to discrepancies from the upstream decompilation. A special thanks goes to the following!
```
TheXaman
Ketsuban
Pyredrid
AsparagusEduardo
Ghoulslash
ExboSeed
Sierraffinity
Jaizu
```