### PR TITLE
Highlight Pokemon Stats by Nature

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,17 +8,39 @@ undertaken with the intention of creating a [ROM Hack].
 The primary objective of this ROM Hack is to elevate the _challenge_ and
 _gameplay_ elements while retaining the nostalgic essence of the original game.
 
+While doing so, the project aims to be meticulous in preserving the nostalgic
+essence of the original game, ensuring that long-time fans and newcomers alike
+can appreciate the journey. By introducing minor **quality of life
+improvements**, opportunity for **increased challenge**, and **gameplay
+balances** the ROM Hack aims to strike a balance between honoring the classic
+gameplay and offering new experiences. This meticulous blend ensures that
+players will encounter familiar moments intertwined with fun and exciting new
+challenges.
+
 ## Changes Made
 
-I've identified specific elements that, do not contribute positively to the
-gameplay experience:
+This project has identified specific elements that do not directly contribute to
+the gameplay experience. By analyzing various components and aspects of the game
+design, the project has pinpointed areas that might be superfluous or detract
+from the core gaming experience.
 
-- TBD
+The aim to refine and optimize the game's design, ensuring that players receive
+the same cohesive and engaging experience.
+
+- Display [Nature Stat Modifiers] in the Pokémon Summary
+  - Frequently, it's frustrating to have to remember or look up natures to
+    determine how a Pokémon's stats will be affected.
 
 ## What Remains Unchanged
 
-While various features might enhance subsequent Pokémon titles, we've chosen to
-maintain the original charm of Gen 3 with the following decisions:
+While various features might enhance subsequent Pokémon titles, the project has
+chosen to maintain the original charm of Gen 3 with the following decisions.
+
+This decision ensures that long-time fans can relive their cherished memories
+while also introducing newer generations to the gameplay that defined this era
+of Pokémon games. Additionally, we've focused on refining gameplay mechanics
+that resonate with the core essence of Gen 3, such as the iconic Pokémon
+abilities and the intricate balance between various types.
 
 - No introduction of new Pokémon
 - No addition of new types
@@ -27,19 +49,18 @@ maintain the original charm of Gen 3 with the following decisions:
 - Retention of single-use TMs
 - No [Physical/Special split]
 
-> [!NOTE]
-> [**pokeemerald.gba**](https://datomatic.no-intro.org/index.php?page=show_record&s=23&n=1961) `sha1: f3ae088181bf583e55daf962a92bb46f4f1d07b7`
-
-
 ## Development Setup
 
 For detailed setup instructions, please refer to [INSTALL.md](INSTALL.md).
 
 ## Acknowledgments
 
-This endeavor owes a considerable debt of gratitude to [pret]. For further
-information about [pret] and additional projects, visit
-[pret.github.io](https://pret.github.io/).
+This project owes a considerable debt of gratitude to [pret] and their
+community. For further information about pret and additional projects, visit
+[pret.github.io].
+
+> [!NOTE]
+> [**pokeemerald.gba**](https://datomatic.no-intro.org/index.php?page=show_record&s=23&n=1961) `sha1: f3ae088181bf583e55daf962a92bb46f4f1d07b7`
 
 [Decompilation]: https://en.wikipedia.org/wiki/Decompiler
 [Pokémon Emerald]: https://en.wikipedia.org/wiki/Pok%C3%A9mon_Emerald
@@ -47,3 +68,4 @@ information about [pret] and additional projects, visit
 [Physical/Special split]: https://bulbapedia.bulbagarden.net/wiki/Damage_category#Physical.2FSpecial_split
 [pret]: https://github.com/pret
 [pret.github.io]: https://pret.github.io/
+[Nature Stat Modifiers]: https://bulbapedia.bulbagarden.net/wiki/Nature#List_of_Natures

--- a/src/pokemon_summary_screen.c
+++ b/src/pokemon_summary_screen.c
@@ -310,6 +310,7 @@ static void SpriteCB_MoveSelector(struct Sprite *);
 static void DestroyMoveSelectorSprites(u8);
 static void SetMainMoveSelectorColor(u8);
 static void KeepMoveSelectorVisible(u8);
+static void BufferStat(u8 *, s8, u32, u32, u32);
 static void SummaryScreen_DestroyAnimDelayTask(void);
 
 // const rom data
@@ -3362,21 +3363,17 @@ static void PrintRibbonCount(void)
 
 static void BufferLeftColumnStats(void)
 {
-    u8 *currentHPString = Alloc(8);
-    u8 *maxHPString = Alloc(8);
-    u8 *attackString = Alloc(8);
-    u8 *defenseString = Alloc(8);
-
-    ConvertIntToDecimalStringN(currentHPString, sMonSummaryScreen->summary.currentHP, STR_CONV_MODE_RIGHT_ALIGN, 3);
-    ConvertIntToDecimalStringN(maxHPString, sMonSummaryScreen->summary.maxHP, STR_CONV_MODE_RIGHT_ALIGN, 3);
-    ConvertIntToDecimalStringN(attackString, sMonSummaryScreen->summary.atk, STR_CONV_MODE_RIGHT_ALIGN, 7);
-    ConvertIntToDecimalStringN(defenseString, sMonSummaryScreen->summary.def, STR_CONV_MODE_RIGHT_ALIGN, 7);
+    u8 *currentHPString = Alloc(20);
+    u8 *maxHPString = Alloc(20);
+    u8 *attackString = Alloc(20);
+    u8 *defenseString = Alloc(20);
+    const s8 *natureMod = gNatureStatTable[sMonSummaryScreen->summary.nature];
 
     DynamicPlaceholderTextUtil_Reset();
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(0, currentHPString);
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(1, maxHPString);
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(2, attackString);
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(3, defenseString);
+    BufferStat(currentHPString, 0, sMonSummaryScreen->summary.currentHP, 0, 3);
+    BufferStat(maxHPString, 0, sMonSummaryScreen->summary.maxHP, 1, 3);
+    BufferStat(attackString, natureMod[STAT_ATK - 1], sMonSummaryScreen->summary.atk, 2, 7);
+    BufferStat(defenseString, natureMod[STAT_DEF - 1], sMonSummaryScreen->summary.def, 3, 7);
     DynamicPlaceholderTextUtil_ExpandPlaceholders(gStringVar4, sStatsLeftColumnLayout);
 
     Free(currentHPString);
@@ -3392,14 +3389,12 @@ static void PrintLeftColumnStats(void)
 
 static void BufferRightColumnStats(void)
 {
-    ConvertIntToDecimalStringN(gStringVar1, sMonSummaryScreen->summary.spatk, STR_CONV_MODE_RIGHT_ALIGN, 3);
-    ConvertIntToDecimalStringN(gStringVar2, sMonSummaryScreen->summary.spdef, STR_CONV_MODE_RIGHT_ALIGN, 3);
-    ConvertIntToDecimalStringN(gStringVar3, sMonSummaryScreen->summary.speed, STR_CONV_MODE_RIGHT_ALIGN, 3);
+    const s8 *natureMod = gNatureStatTable[sMonSummaryScreen->summary.nature];
 
     DynamicPlaceholderTextUtil_Reset();
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(0, gStringVar1);
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(1, gStringVar2);
-    DynamicPlaceholderTextUtil_SetPlaceholderPtr(2, gStringVar3);
+    BufferStat(gStringVar1, natureMod[STAT_SPATK - 1], sMonSummaryScreen->summary.spatk, 0, 3);
+    BufferStat(gStringVar2, natureMod[STAT_SPDEF - 1], sMonSummaryScreen->summary.spdef, 1, 3);
+    BufferStat(gStringVar3, natureMod[STAT_SPEED - 1], sMonSummaryScreen->summary.speed, 2, 3);
     DynamicPlaceholderTextUtil_ExpandPlaceholders(gStringVar4, sStatsRightColumnLayout);
 }
 
@@ -4152,4 +4147,22 @@ static void KeepMoveSelectorVisible(u8 firstSpriteId)
         gSprites[spriteIds[i]].data[1] = 0;
         gSprites[spriteIds[i]].invisible = FALSE;
     }
+}
+
+static void BufferStat(u8 *dst, s8 natureMod, u32 stat, u32 strId, u32 n)
+{
+    static const u8 sTextNatureDown[] = _("{COLOR}{08}");
+    static const u8 sTextNatureUp[] = _("{COLOR}{05}");
+    static const u8 sTextNatureNeutral[] = _("{COLOR}{01}");
+    u8 *txtPtr;
+
+    if (natureMod == 0)
+        txtPtr = StringCopy(dst, sTextNatureNeutral);
+    else if (natureMod > 0)
+        txtPtr = StringCopy(dst, sTextNatureUp);
+    else
+        txtPtr = StringCopy(dst, sTextNatureDown);
+
+    ConvertIntToDecimalStringN(txtPtr, stat, STR_CONV_MODE_RIGHT_ALIGN, n);
+    DynamicPlaceholderTextUtil_SetPlaceholderPtr(strId, dst);
 }


### PR DESCRIPTION
## What

Display [Nature Stat Modifiers] in the Pokémon Summary. Frequently, it's frustrating to have to remember or look up natures to determine how a Pokémon's stats will be affected.

![](https://camo.githubusercontent.com/5cc1f4c091913970df5d9171fa039d8938ef49beb3e512c30203f3bd86fb495f/68747470733a2f2f692e696d6775722e636f6d2f4a5a4e567a30312e706e67)

Complete Guide Followed: https://github.com/pret/pokeemerald/wiki/Colored-stats-by-nature-in-summary-screen

[Nature Stat Modifiers]: https://bulbapedia.bulbagarden.net/wiki/Nature#List_of_Natures