### PR TITLE
Allow running indoors

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ a fun and engaging experience.
   - This feature eliminates the need for tedious tools or resources,
     streamlining the gameplay experience and empowering players with essential
     information at their fingertips.
+- Allow running indoors
+  - By removing movement restrictions indoors, players can navigate
+    environments swiftly, ensuring that transitions between indoor and outdoor
+    settings are seamless and maintain a brisk pace.
 
 ## What Remains Unchanged
 

--- a/src/bike.c
+++ b/src/bike.c
@@ -1053,7 +1053,7 @@ void Bike_HandleBumpySlopeJump(void)
 
 bool32 IsRunningDisallowed(u8 metatile)
 {
-    if (!gMapHeader.allowRunning || IsRunningDisallowedByMetatile(metatile) == TRUE)
+    if (IsRunningDisallowedByMetatile(metatile) == TRUE)
         return TRUE;
     else
         return FALSE;


### PR DESCRIPTION
## What
This is a pretty simple change, but allows the player to run indoors.  By removing movement restrictions indoors, players can navigate environments swiftly, ensuring that transitions between indoor and outdoor settings are seamless and maintain a brisk pace.

Example: https://github.com/pret/pokeemerald/wiki/Allow-running-indoors