### PR TITLE
Swap damage types for Ghost/Dark

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,10 @@ _gameplay_ elements while retaining the nostalgic essence of the original game.
 While doing so, the project aims to be meticulous in preserving the sentimental
 quality of the original game, ensuring that long-time fans and newcomers alike
 can appreciate the journey. By introducing minor **quality of life
-improvements**, opportunity for **increased challenge**, and **combat
-balances** the ROM Hack aims to strike a balance between honoring the classic
-gameplay and offering new experiences. This meticulous blend ensures that
-players will encounter familiar moments intertwined with fun and exciting new
-challenges.
+improvements**, opportunity for **increased challenge**, and **combat balances**
+the ROM Hack aims to strike a balance between honoring the classic gameplay and
+offering new experiences. This meticulous blend ensures that players will
+encounter familiar moments intertwined with fun and exciting new challenges.
 
 ## Changes Made
 
@@ -24,8 +23,8 @@ the gameplay experience. By analyzing various components and aspects of the game
 design, the project has pinpointed areas that might be superfluous or detract
 from the core gaming experience.
 
-The aim is to refine and optimize the game's design, ensuring that players receive
-a fun and engaging experience.
+The aim is to refine and optimize the game's design, ensuring that players
+receive a fun and engaging experience.
 
 - Display [Nature Stat Modifiers] in the Pokémon Summary
   - Frequently, it's frustrating to have to remember or look up natures to
@@ -35,13 +34,21 @@ a fun and engaging experience.
     streamlining the gameplay experience and empowering players with essential
     information at their fingertips.
 - Allow running indoors
-  - By removing movement restrictions indoors, players can navigate
-    environments swiftly, ensuring that transitions between indoor and outdoor
-    settings are seamless and maintain a brisk pace.
+  - By removing movement restrictions indoors, players can navigate environments
+    swiftly, ensuring that transitions between indoor and outdoor settings are
+    seamless and maintain a brisk pace.
 - Increase Item Bag Size from 30 to 120
   - This increase not only allows players to carry more items but also reduces
     the frequency of having to manage and shuffle items between the bag and
     storage. Consequently, players can focus more on exploring and battling.
+- Adjust Damage Calculatation for Dark/Ghost Type Moves
+  - The calculation for Ghost-type moves now utilizes special stats rather than
+    physical ones. Historically, Ghost Pokémon in earlier generations were
+    designed around dealing special damage. This adjustment aims to enhance
+    their effectiveness and overall enjoyment in battles.
+  - Conversely, Dark-type moves now factor in physical stats instead of special
+    ones. Given that Dark-type Pokémon typically excel as physical attackers,
+    this change aligns more closely with their inherent strengths.
 
 ## What Remains Unchanged
 
@@ -72,7 +79,7 @@ community. For further information about pret and additional projects, visit
 [pret.github.io].
 
 > [!NOTE]
-> [**pokeemerald.gba**](https://datomatic.no-intro.org/index.php?page=show_record&s=23&n=1961) `sha1: f3ae088181bf583e55daf962a92bb46f4f1d07b7`
+> Decompilation Target: [**pokeemerald.gba**](https://datomatic.no-intro.org/index.php?page=show_record&s=23&n=1961) `sha1: f3ae088181bf583e55daf962a92bb46f4f1d07b7`
 
 [Decompilation]: https://en.wikipedia.org/wiki/Decompiler
 [Pokémon Emerald]: https://en.wikipedia.org/wiki/Pok%C3%A9mon_Emerald

--- a/data/battle_ai_scripts.s
+++ b/data/battle_ai_scripts.s
@@ -949,7 +949,7 @@ AI_CV_DefenseUp_PhysicalTypes:
 	.byte TYPE_FLYING
 	.byte TYPE_ROCK
 	.byte TYPE_BUG
-	.byte TYPE_GHOST
+	.byte TYPE_DARK
 	.byte TYPE_STEEL
 	.byte -1
 
@@ -1020,7 +1020,7 @@ AI_CV_SpDefUp_PhysicalTypes:
 	.byte TYPE_FLYING
 	.byte TYPE_ROCK
 	.byte TYPE_BUG
-	.byte TYPE_GHOST
+	.byte TYPE_DARK
 	.byte TYPE_STEEL
 	.byte -1
 
@@ -1180,7 +1180,7 @@ AI_CV_SpAtkDown_SpecialTypeList:
 	.byte TYPE_PSYCHIC
 	.byte TYPE_ICE
 	.byte TYPE_DRAGON
-	.byte TYPE_DARK
+	.byte TYPE_GHOST
 	.byte -1
 
 AI_CV_SpDefDown:
@@ -1390,7 +1390,7 @@ AI_CV_LightScreen_SpecialTypeList:
 	.byte TYPE_PSYCHIC
 	.byte TYPE_ICE
 	.byte TYPE_DRAGON
-	.byte TYPE_DARK
+	.byte TYPE_GHOST
 	.byte -1
 
 AI_CV_Rest:
@@ -1509,7 +1509,7 @@ AI_CV_Reflect_PhysicalTypeList:
 	.byte TYPE_GROUND
 	.byte TYPE_ROCK
 	.byte TYPE_BUG
-	.byte TYPE_GHOST
+	.byte TYPE_DARK
 	.byte TYPE_STEEL
 	.byte -1
 
@@ -1669,7 +1669,7 @@ AI_CV_Counter_PhysicalTypeList:
 	.byte TYPE_GROUND
 	.byte TYPE_ROCK
 	.byte TYPE_BUG
-	.byte TYPE_GHOST
+	.byte TYPE_DARK
 	.byte TYPE_STEEL
 	.byte -1
 
@@ -2156,7 +2156,7 @@ AI_CV_MirrorCoat_SpecialTypeList:
 	.byte TYPE_PSYCHIC
 	.byte TYPE_ICE
 	.byte TYPE_DRAGON
-	.byte TYPE_DARK
+	.byte TYPE_GHOST
 	.byte -1
 
 AI_CV_ChargeUpMove:

--- a/include/constants/pokemon.h
+++ b/include/constants/pokemon.h
@@ -10,7 +10,7 @@
 #define TYPE_GROUND           4
 #define TYPE_ROCK             5
 #define TYPE_BUG              6
-#define TYPE_GHOST            7
+#define TYPE_DARK             7
 #define TYPE_STEEL            8
 #define TYPE_MYSTERY          9
 #define TYPE_FIRE             10
@@ -20,7 +20,7 @@
 #define TYPE_PSYCHIC          14
 #define TYPE_ICE              15
 #define TYPE_DRAGON           16
-#define TYPE_DARK             17
+#define TYPE_GHOST            17
 #define NUMBER_OF_MON_TYPES   18
 
 // Pokémon egg groups


### PR DESCRIPTION
## What
Adjust Damage Calculatation for Dark/Ghost Type Moves.

- The calculation for Ghost-type moves now utilizes special stats rather than physical ones. Historically, Ghost Pokémon in earlier generations were designed around dealing special damage. This adjustment aims to enhance their effectiveness and overall enjoyment in battles.
- Conversely, Dark-type moves now factor in physical stats instead of special ones. Given that Dark-type Pokémon typically excel as physical attackers, this change aligns more closely with their inherent strengths.

This change was pretty straight forward, since the macros for calculating damage types is as follows.
```C
#define IS_TYPE_PHYSICAL(moveType)(moveType < TYPE_MYSTERY)
#define IS_TYPE_SPECIAL(moveType)(moveType > TYPE_MYSTERY)
```

And the enumerations are as follows...

```C
// Pokémon types
#define TYPE_NONE             255
#define TYPE_NORMAL           0
#define TYPE_FIGHTING         1
#define TYPE_FLYING           2
#define TYPE_POISON           3
#define TYPE_GROUND           4
#define TYPE_ROCK             5
#define TYPE_BUG              6
#define TYPE_GHOST            7
#define TYPE_STEEL            8
#define TYPE_MYSTERY          9
#define TYPE_FIRE             10
#define TYPE_WATER            11
#define TYPE_GRASS            12
#define TYPE_ELECTRIC         13
#define TYPE_PSYCHIC          14
#define TYPE_ICE              15
#define TYPE_DRAGON           16
#define TYPE_DARK             17
#define NUMBER_OF_MON_TYPES   18
```

Since the physical/special split pivots between `TYPE_MYSTERY` we only had to swap the `TYPE_DARK` and `TYPE_GHOST` values.