### PR TITLE
Speed up nurse joy interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,11 @@ receive a fun and engaging experience.
     Bike, hold the "R" button while riding the Acro Bike. This seamless
     integration enhances navigation and streamlines the overall gameplay
     experience.
+- Speed up Tedious Interactions
+  - To streamline gameplay and minimize the time players spend on tedious
+    interactions, such as healing Pokémon at the Pokécenter, this project
+    has reduced both wait times and required player inputs for various
+    activities.
 
 ## What Remains Unchanged
 

--- a/data/scripts/pkmn_center_nurse.inc
+++ b/data/scripts/pkmn_center_nurse.inc
@@ -4,9 +4,8 @@ Common_EventScript_PkmnCenterNurse::
 	setvar VAR_0x8004, 0
 	specialvar VAR_RESULT, CountPlayerTrainerStars
 	goto_if_eq VAR_RESULT, 4, EventScript_PkmnCenterNurse_GoldCard
-	msgbox gText_WouldYouLikeToRestYourPkmn, MSGBOX_YESNO
-	goto_if_eq VAR_RESULT, YES, EventScript_PkmnCenterNurse_HealPkmn
-	goto_if_eq VAR_RESULT, NO, EventScript_PkmnCenterNurse_Goodbye
+	message gText_WelcomeToPkmnCenter
+	goto EventScript_PkmnCenterNurse_HealPkmn
 	end
 
 EventScript_PkmnCenterNurse_Goodbye::
@@ -59,6 +58,7 @@ EventScript_PkmnCenterNurse_ReturnPkmn::
 	applymovement VAR_0x800B, Movement_PkmnCenterNurse_Bow
 	waitmovement 0
 	message gText_WeHopeToSeeYouAgain
+	goto EventScript_PkmnCenterNurse_PlayerTurn
 	return
 
 EventScript_PkmnCenterNurse_ReturnPkmn2::
@@ -67,6 +67,7 @@ EventScript_PkmnCenterNurse_ReturnPkmn2::
 	applymovement VAR_0x800B, Movement_PkmnCenterNurse_Bow
 	waitmovement 0
 	message gText_WeHopeToSeeYouAgain2
+	goto EventScript_PkmnCenterNurse_PlayerTurn
 	return
 
 EventScript_PkmnCenterNurse_PlayerWaitingInUnionRoom::
@@ -120,3 +121,10 @@ Movement_PkmnCenterNurse_Bow:
 	nurse_joy_bow
 	delay_4
 	step_end
+
+EventScript_PkmnCenterNurse_PlayerTurn::
+	closemessage
+	applymovement OBJ_EVENT_ID_PLAYER, Common_Movement_FaceDown
+	waitmovement 0
+	release
+	end

--- a/data/text/pkmn_center_nurse.inc
+++ b/data/text/pkmn_center_nurse.inc
@@ -1,9 +1,6 @@
-gText_WouldYouLikeToRestYourPkmn::
-	.string "Hello, and welcome to\n"
-	.string "the POKéMON CENTER.\p"
-	.string "We restore your tired POKéMON\n"
-	.string "to full health.\p"
-	.string "Would you like to rest your POKéMON?$"
+gText_WelcomeToPkmnCenter::
+	.string "Welcome to the POKéMON CENTER.\n"
+	.string "I'll restore your tired POKéMON.$"
 
 gText_IllTakeYourPkmn::
 	.string "Okay, I'll take your POKéMON\n"

--- a/src/field_effect.c
+++ b/src/field_effect.c
@@ -1147,7 +1147,7 @@ static void PokeballGlowEffect_PlaceBalls(struct Sprite *sprite)
     u8 spriteId;
     if (sprite->sTimer == 0 || (--sprite->sTimer) == 0)
     {
-        sprite->sTimer = 25;
+        sprite->sTimer = 10;
         spriteId = CreateSpriteAtEnd(&sSpriteTemplate_PokeballGlow, sPokeballCoordOffsets[sprite->sCounter].x + sprite->x2, sPokeballCoordOffsets[sprite->sCounter].y + sprite->y2, 0);
         gSprites[spriteId].oam.priority = 2;
         gSprites[spriteId].sEffectSpriteId = sprite->sSpriteId;


### PR DESCRIPTION
## What
These changes expedite interactions with Nurse Joy by enabling auto-healing, eliminating the need for the yes/no dialogue prompt. Additionally, the animation that individually places Poké Balls has been sped up.
