### PR TITLE
Prompt for re-using repels

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,9 @@ receive a fun and engaging experience.
     activities.
 - Ask for [Repel] Reuse After Expiration
   - Recognizing the inconvenience of frequent encounters in high-density
-    regions, when a [Repel] wears off, players will now receive a prompt asking
-    if they'd like to use another [Repel] from their bag if available. This aims
-    to increase the usability and convenience of [Repel] items.
+    regions, when a Repel wears off, players will now receive a prompt asking
+    if they'd like to use another Repel from their bag if available. This aims
+    to increase the usability and convenience of Repel items.
 
 ## What Remains Unchanged
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ receive a fun and engaging experience.
     interactions, such as healing Pokémon at the Pokécenter, this project
     has reduced both wait times and required player inputs for various
     activities.
-- Ask for [Repel] Refresh After Expiration
+- Ask for [Repel] Reuse After Expiration
   - Recognizing the inconvenience of frequent encounters in high-density
     regions, when a [Repel] wears off, players will now receive a prompt asking
     if they'd like to use another [Repel] from their bag if available. This aims

--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ receive a fun and engaging experience.
     interactions, such as healing Pokémon at the Pokécenter, this project
     has reduced both wait times and required player inputs for various
     activities.
-- Prompt Repel Refresh
+- Ask for [Repel] Refresh After Expiration
   - Recognizing the inconvenience of frequent encounters in high-density
-    regions, when a Repel wears off, players will now receive a prompt asking
-    if they'd like to use another Repel from their bag if available. This aims
-    to increase the usability and convenience of Repels.
+    regions, when a [Repel] wears off, players will now receive a prompt asking
+    if they'd like to use another [Repel] from their bag if available. This aims
+    to increase the usability and convenience of [Repel] items.
 
 ## What Remains Unchanged
 
@@ -106,3 +106,4 @@ community. For further information about pret and additional projects, visit
 [pret.github.io]: https://pret.github.io/
 [Nature Stat Modifiers]: https://bulbapedia.bulbagarden.net/wiki/Nature#List_of_Natures
 [EV/IV Values]: https://www.smogon.com/ingame/guides/evs_ivs
+[Repel]: https://bulbapedia.bulbagarden.net/wiki/Repel

--- a/README.md
+++ b/README.md
@@ -61,6 +61,11 @@ receive a fun and engaging experience.
     interactions, such as healing Pokémon at the Pokécenter, this project
     has reduced both wait times and required player inputs for various
     activities.
+- Prompt Repel Refresh
+  - Recognizing the inconvenience of frequent encounters in high-density
+    regions, when a Repel wears off, players will now receive a prompt asking
+    if they'd like to use another Repel from their bag if available. This aims
+    to increase the usability and convenience of Repels.
 
 ## What Remains Unchanged
 

--- a/data/scripts/repel.inc
+++ b/data/scripts/repel.inc
@@ -1,6 +1,34 @@
 EventScript_RepelWoreOff::
+	lockall
+	checkitem VAR_REPEL_LAST_USED, 1
+	compare VAR_RESULT, FALSE
+	goto_if_eq EventScript_RepelWoreOff_NoMoreRepels
+	msgbox Text_RepelWoreOff_UseAnother, MSGBOX_YESNO
+	compare VAR_RESULT, 0
+	goto_if_eq EventScript_RepelWoreOff_ChooseNo
+	copyvar VAR_0x8004, VAR_REPEL_LAST_USED
+	callnative ItemId_GetHoldEffectParam_Script
+	copyvar VAR_REPEL_STEP_COUNT, VAR_RESULT
+	bufferitemname 1, VAR_REPEL_LAST_USED
+	removeitem VAR_REPEL_LAST_USED, 1
+	playse SE_REPEL
+	msgbox gText_PlayerUsedVar2, MSGBOX_SIGN
+	goto EventScript_RepelWoreOff_End
+
+EventScript_RepelWoreOff_ChooseNo:
+	closemessage
+	goto EventScript_RepelWoreOff_End
+
+EventScript_RepelWoreOff_NoMoreRepels:
 	msgbox Text_RepelWoreOff, MSGBOX_SIGN
+
+EventScript_RepelWoreOff_End:
+	releaseall
 	end
 
 Text_RepelWoreOff:
 	.string "REPEL's effect wore off…$"
+
+Text_RepelWoreOff_UseAnother:
+	.string "REPEL's effect wore off…\n"
+	.string "Use another?$"

--- a/include/constants/vars.h
+++ b/include/constants/vars.h
@@ -95,7 +95,7 @@
 #define VAR_POKELOT_RND1                                 0x404B
 #define VAR_POKELOT_RND2                                 0x404C
 #define VAR_POKELOT_PRIZE_PLACE                          0x404D
-#define VAR_UNUSED_0x404E                                0x404E // Unused Var
+#define VAR_REPEL_LAST_USED                              0x404E
 #define VAR_LOTAD_SIZE_RECORD                            0x404F
 #define VAR_LITTLEROOT_TOWN_STATE                        0x4050
 #define VAR_OLDALE_TOWN_STATE                            0x4051

--- a/include/item.h
+++ b/include/item.h
@@ -66,6 +66,7 @@ const u8 *ItemId_GetName(u16 itemId);
 u16 ItemId_GetPrice(u16 itemId);
 u8 ItemId_GetHoldEffect(u16 itemId);
 u8 ItemId_GetHoldEffectParam(u16 itemId);
+void ItemId_GetHoldEffectParam_Script();
 const u8 *ItemId_GetDescription(u16 itemId);
 u8 ItemId_GetImportance(u16 itemId);
 u8 ItemId_GetPocket(u16 itemId);

--- a/src/item.c
+++ b/src/item.c
@@ -884,6 +884,11 @@ u8 ItemId_GetHoldEffectParam(u16 itemId)
     return gItems[SanitizeItemId(itemId)].holdEffectParam;
 }
 
+void ItemId_GetHoldEffectParam_Script()
+{
+    VarSet(VAR_RESULT, ItemId_GetHoldEffectParam(VarGet(VAR_0x8004)));
+}
+
 const u8 *ItemId_GetDescription(u16 itemId)
 {
     return gItems[SanitizeItemId(itemId)].description;

--- a/src/item_use.c
+++ b/src/item_use.c
@@ -856,6 +856,7 @@ static void Task_UseRepel(u8 taskId)
     if (!IsSEPlaying())
     {
         VarSet(VAR_REPEL_STEP_COUNT, ItemId_GetHoldEffectParam(gSpecialVar_ItemId));
+        VarSet(VAR_REPEL_LAST_USED, gSpecialVar_ItemId);
         RemoveUsedItem();
         if (!InBattlePyramid())
             DisplayItemMessage(taskId, FONT_NORMAL, gStringVar4, CloseItemMessage);


### PR DESCRIPTION
## What
Recognizing the inconvenience of frequent encounters in high-density regions, when a Repel wears off, players will now receive a prompt asking if they'd like to use another Repel from their bag if available. This aims to increase the usability and convenience of Repels.

Guide: https://github.com/pret/pokeemerald/wiki/Prompt-for-reusing-Repels