### PR TITLE
Remove Timings on Fishing

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,10 @@ receive a fun and engaging experience.
     introduced. This ensures that players have more flexibility in evolving
     their Pokémon without being constrained by game availability or trading with
     others.
+- Remove Timings on Fishing
+  - To help remove the tedious mini-game and streamline fishing for Pokémon,
+    the project has removed specific timings, providing players with a smoother
+    fishing experience.
 
 ## What Remains Unchanged
 

--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1788,10 +1788,8 @@ static bool8 Fishing_ShowDots(struct Task *task)
     task->tFrameCounter++;
     if (JOY_NEW(A_BUTTON))
     {
-        task->tStep = FISHING_NO_BITE;
-        if (task->tRoundsPlayed != 0)
-            task->tStep = FISHING_GOT_AWAY;
-        return TRUE;
+        task->tStep = FISHING_GOT_BITE;
+        return FALSE;
     }
     else
     {
@@ -1800,7 +1798,7 @@ static bool8 Fishing_ShowDots(struct Task *task)
             task->tFrameCounter = 0;
             if (task->tNumDots >= task->tDotsRequired)
             {
-                task->tStep++;
+                task->tStep = FISHING_GOT_BITE;
                 if (task->tRoundsPlayed != 0)
                     task->tStep++;
                 task->tRoundsPlayed++;
@@ -1873,9 +1871,7 @@ static bool8 Fishing_WaitForA(struct Task *task)
 
     AlignFishingAnimationFrames();
     task->tFrameCounter++;
-    if (task->tFrameCounter >= reelTimeouts[task->tFishingRod])
-        task->tStep = FISHING_GOT_AWAY;
-    else if (JOY_NEW(A_BUTTON))
+    if (JOY_NEW(A_BUTTON))
         task->tStep++;
     return FALSE;
 }
@@ -1892,18 +1888,6 @@ static bool8 Fishing_CheckMoreDots(struct Task *task)
 
     AlignFishingAnimationFrames();
     task->tStep++;
-    if (task->tRoundsPlayed < task->tMinRoundsRequired)
-    {
-        task->tStep = FISHING_START_ROUND;
-    }
-    else if (task->tRoundsPlayed < 2)
-    {
-        // probability of having to play another round
-        s16 probability = Random() % 100;
-
-        if (moreDotsChance[task->tFishingRod][task->tRoundsPlayed] > probability)
-            task->tStep = FISHING_START_ROUND;
-    }
     return FALSE;
 }
 


### PR DESCRIPTION
## What

To help remove the tedious mini-game and streamline fishing for Pokémon, the project has removed specific timings, providing players with a smoother fishing experience.

_Followed this guide:_ https://github.com/pret/pokeemerald/wiki/Fish-Will-Now-Always-Get-on-Hook