### PR TITLE
Fix ground effects on surf dismount

### DIFF
--- a/src/field_player_avatar.c
+++ b/src/field_player_avatar.c
@@ -1663,6 +1663,7 @@ static void Task_WaitStopSurfing(u8 taskId)
         gPlayerAvatar.preventStep = FALSE;
         UnlockPlayerFieldControls();
         DestroySprite(&gSprites[playerObjEvent->fieldEffectSpriteId]);
+        playerObjEvent->triggerGroundEffectsOnMove = TRUE;
         DestroyTask(taskId);
     }
 }


### PR DESCRIPTION
## What

In the original game, when dismounting from surfing into grass, the ground effects were not immediately applied. This modification ensures that ground effects are now applied promptly after surf has ended.

<a href="https://imgur.com/tzppyWl"><img src="https://i.imgur.com/tzppyWl.gif" title="source: imgur.com" /></a> <a href="https://imgur.com/0VdHg2d"><img src="https://i.imgur.com/0VdHg2d.gif" title="source: imgur.com" /></a>