### PR TITLE
49 update in game trade encounters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ receive a fun and engaging experience.
   - Players can now easily view the power and type of the "Hidden Power" move in
     both the Pokémon Summary and Battle UI, enhancing strategic decision-making
     during battles and team building.
+- Update In-Game Trades
+  - Modify/Add In-Game Trades to provide more unique Pokémon.
 
 ## What Remains Unchanged
 

--- a/data/maps/BattleFrontier_Lounge6/scripts.inc
+++ b/data/maps/BattleFrontier_Lounge6/scripts.inc
@@ -5,7 +5,7 @@ BattleFrontier_Lounge6_EventScript_Trader::
 	lock
 	faceplayer
 	goto_if_set FLAG_BATTLE_FRONTIER_TRADE_DONE, BattleFrontier_Lounge6_EventScript_TradeCompleted
-	setvar VAR_0x8008, INGAME_TRADE_MEOWTH
+	setvar VAR_0x8008, INGAME_TRADE_EEVEE
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_0x8009, VAR_RESULT

--- a/data/maps/FortreeCity_House1/scripts.inc
+++ b/data/maps/FortreeCity_House1/scripts.inc
@@ -5,7 +5,7 @@ FortreeCity_House1_EventScript_Trader::
 	lock
 	faceplayer
 	goto_if_set FLAG_FORTREE_NPC_TRADE_COMPLETED, FortreeCity_House1_EventScript_TradeCompleted
-	setvar VAR_0x8008, INGAME_TRADE_PLUSLE
+	setvar VAR_0x8008, INGAME_TRADE_MR_MIME
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_0x8009, VAR_RESULT

--- a/data/maps/PacifidlogTown_House3/scripts.inc
+++ b/data/maps/PacifidlogTown_House3/scripts.inc
@@ -5,7 +5,7 @@ PacifidlogTown_House3_EventScript_Trader::
 	lock
 	faceplayer
 	goto_if_set FLAG_PACIFIDLOG_NPC_TRADE_COMPLETED, PacifidlogTown_House3_EventScript_TradeCompleted
-	setvar VAR_0x8008, INGAME_TRADE_HORSEA
+	setvar VAR_0x8008, INGAME_TRADE_TOGEPI
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_0x8009, VAR_RESULT

--- a/data/maps/RustboroCity_DevonCorp_2F/map.json
+++ b/data/maps/RustboroCity_DevonCorp_2F/map.json
@@ -81,6 +81,19 @@
     },
     {
       "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
+      "x": 10,
+      "y": 8,
+      "elevation": 3,
+      "movement_type": "MOVEMENT_TYPE_FACE_UP",
+      "movement_range_x": 1,
+      "movement_range_y": 1,
+      "trainer_type": "TRAINER_TYPE_NONE",
+      "trainer_sight_or_berry_tree_id": "0",
+      "script": "RustboroCity_DevonCorp_2F_EventScript_TradeScientist",
+      "flag": "0"
+    },
+    {
+      "graphics_id": "OBJ_EVENT_GFX_SCIENTIST_1",
       "x": 14,
       "y": 5,
       "elevation": 3,

--- a/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
+++ b/data/maps/RustboroCity_DevonCorp_2F/scripts.inc
@@ -56,6 +56,70 @@ RustboroCity_DevonCorp_2F_EventScript_PokemonDreamsScientist::
 	release
 	end
 
+RustboroCity_DevonCorp_2F_EventScript_TradeScientist::
+	lock
+	faceplayer
+	goto_if_set FLAG_DEVCORP_NPC_TRADE_COMPLETED, RustboroCity_DevonCorp_2F_TradeCompleted
+	setvar VAR_0x8008, INGAME_TRADE_AERODACTYL
+	copyvar VAR_0x8004, VAR_0x8008
+	specialvar VAR_RESULT, GetInGameTradeSpeciesInfo
+	copyvar VAR_0x8009, VAR_RESULT
+	msgbox RustboroCity_DevonCorp_2F_Text_IllTradeIfYouWant, MSGBOX_YESNO
+	goto_if_eq VAR_RESULT, NO, RustboroCity_DevonCorp_2F_EventScript_DeclineTrade
+	special ChoosePartyMon
+	waitstate
+	copyvar VAR_0x800A, VAR_0x8004
+	goto_if_eq VAR_0x8004, PARTY_NOTHING_CHOSEN, RustboroCity_DevonCorp_2F_EventScript_DeclineTrade
+	copyvar VAR_0x8005, VAR_0x800A
+	specialvar VAR_RESULT, GetTradeSpecies
+	copyvar VAR_0x800B, VAR_RESULT
+	goto_if_ne VAR_RESULT, VAR_0x8009, RustboroCity_DevonCorp_2F_EventScript_NotRequestedMon
+	copyvar VAR_0x8004, VAR_0x8008
+	copyvar VAR_0x8005, VAR_0x800A
+	special CreateInGameTradePokemon
+	special DoInGameTradeScene
+	waitstate
+	msgbox RustboroCity_DevonCorp_2F_Text_PleaseBeGoodToMyPokemon, MSGBOX_DEFAULT
+	setflag FLAG_DEVCORP_NPC_TRADE_COMPLETED
+	release
+	end
+
+RustboroCity_DevonCorp_2F_EventScript_DeclineTrade::
+	msgbox RustboroCity_DevonCorp_2F_Text_YouDontWantToThatsOkay, MSGBOX_DEFAULT
+	release
+	end
+
+RustboroCity_DevonCorp_2F_EventScript_NotRequestedMon::
+	bufferspeciesname STR_VAR_1, VAR_0x8009
+	msgbox RustboroCity_DevonCorp_2F_Text_DoesntLookLikeMonToMe, MSGBOX_DEFAULT
+	release
+	end
+
+RustboroCity_DevonCorp_2F_TradeCompleted::
+	msgbox RustboroCity_DevonCorp_2F_Text_ThankYou, MSGBOX_DEFAULT
+	release
+	end
+
+RustboroCity_DevonCorp_2F_Text_IllTradeIfYouWant:
+	.string "I have a POKéMON we resurrected!\n"
+	.string "I'd be willing to trade to show you.\p"
+	.string "I'll trade you my {STR_VAR_2} for\n"
+	.string "a {STR_VAR_1} if you want.$"
+
+RustboroCity_DevonCorp_2F_Text_PleaseBeGoodToMyPokemon:
+	.string "Take care of them.\n"
+	.string "{STR_VAR_1} is quite a specimen.$"
+
+RustboroCity_DevonCorp_2F_Text_YouDontWantToThatsOkay:
+	.string "Oh, if you don't want to, that's okay.$"
+
+RustboroCity_DevonCorp_2F_Text_DoesntLookLikeMonToMe:
+	.string "Huh? That doesn't look anything like\n"
+	.string "a {STR_VAR_1} to me.$"
+
+RustboroCity_DevonCorp_2F_Text_ThankYou:
+	.string "Thank you!$"
+
 RustboroCity_DevonCorp_2F_EventScript_FossilScientist::
 	lock
 	faceplayer

--- a/data/maps/RustboroCity_House1/scripts.inc
+++ b/data/maps/RustboroCity_House1/scripts.inc
@@ -5,7 +5,7 @@ RustboroCity_House1_EventScript_Trader::
 	lock
 	faceplayer
 	goto_if_set FLAG_RUSTBORO_NPC_TRADE_COMPLETED, RustboroCity_House1_EventScript_TradeCompleted
-	setvar VAR_0x8008, INGAME_TRADE_SEEDOT
+	setvar VAR_0x8008, INGAME_TRADE_FARFETCHD
 	copyvar VAR_0x8004, VAR_0x8008
 	specialvar VAR_RESULT, GetInGameTradeSpeciesInfo
 	copyvar VAR_0x8009, VAR_RESULT

--- a/include/constants/flags.h
+++ b/include/constants/flags.h
@@ -168,7 +168,7 @@
 #define FLAG_MR_BRINEY_SAILING_INTRO         0x93
 #define FLAG_DOCK_REJECTED_DEVON_GOODS       0x94
 #define FLAG_DELIVERED_DEVON_GOODS           0x95
-#define FLAG_RECEIVED_CONTEST_PASS           0x96 // Unused, leftover from R/S
+#define FLAG_DEVCORP_NPC_TRADE_COMPLETED     0x96 // Emerald Refined: Aerodactyl Trade
 #define FLAG_RECEIVED_CASTFORM               0x97
 #define FLAG_RECEIVED_SUPER_ROD              0x98
 #define FLAG_RUSTBORO_NPC_TRADE_COMPLETED    0x99

--- a/include/constants/trade.h
+++ b/include/constants/trade.h
@@ -5,10 +5,11 @@
 #define TRADE_PARTNER 1
 
 // In-game Trade IDs
-#define INGAME_TRADE_SEEDOT 0
-#define INGAME_TRADE_PLUSLE 1
-#define INGAME_TRADE_HORSEA 2
-#define INGAME_TRADE_MEOWTH 3
+#define INGAME_TRADE_FARFETCHD 0
+#define INGAME_TRADE_MR_MIME 1
+#define INGAME_TRADE_TOGEPI 2
+#define INGAME_TRADE_EEVEE 3
+#define INGAME_TRADE_AERODACTYL 4
 
 // Return values for CanTradeSelectedMon and CanSpinTradeMon
 #define CAN_TRADE_MON              0

--- a/src/data/trade.h
+++ b/src/data/trade.h
@@ -984,15 +984,15 @@ static const union AffineAnimCmd *const sAffineAnims_CrossingMonPics[] =
 
 static const struct InGameTrade sIngameTrades[] =
 {
-    [INGAME_TRADE_SEEDOT] =
+    [INGAME_TRADE_FARFETCHD] =
     {
-        .nickname = _("DOTS"),
-        .species = SPECIES_SEEDOT,
-        .ivs = {5, 4, 5, 4, 4, 4},
+        .nickname = _("HOWARD"),
+        .species = SPECIES_FARFETCHD,
+        .ivs = {21, 24, 21, 23, 19, 15},
         .abilityNum = 1,
         .otId = 38726,
         .conditions = {30, 5, 5, 5, 5},
-        .personality = 0x84,
+        .personality = 0x8A, // JOLLY
         .heldItem = ITEM_CHESTO_BERRY,
         .mailNum = -1,
         .otName = _("KOBE"),
@@ -1000,31 +1000,31 @@ static const struct InGameTrade sIngameTrades[] =
         .sheen = 10,
         .requestedSpecies = SPECIES_RALTS
     },
-    [INGAME_TRADE_PLUSLE] =
+    [INGAME_TRADE_MR_MIME] =
     {
-        .nickname = _("PLUSES"),
-        .species = SPECIES_PLUSLE,
-        .ivs = {4, 4, 4, 5, 5, 4},
+        .nickname = _("CHARLIE"),
+        .species = SPECIES_MR_MIME,
+        .ivs = {21, 15, 21, 24, 19, 23},
         .abilityNum = 0,
         .otId = 73996,
         .conditions = {5, 5, 30, 5, 5},
-        .personality = 0x6F,
+        .personality = 0x7B, // CAREFUL
         .heldItem = ITEM_WOOD_MAIL,
         .mailNum = 0,
         .otName = _("ROMAN"),
         .otGender = MALE,
         .sheen = 10,
-        .requestedSpecies = SPECIES_VOLBEAT
+        .requestedSpecies = SPECIES_ABRA
     },
-    [INGAME_TRADE_HORSEA] =
+    [INGAME_TRADE_TOGEPI] =
     {
-        .nickname = _("SEASOR"),
-        .species = SPECIES_HORSEA,
-        .ivs = {5, 4, 4, 4, 5, 4},
-        .abilityNum = 0,
+        .nickname = _("TOMAGO"),
+        .species = SPECIES_TOGEPI,
+        .ivs = {21, 15, 21, 19, 23, 24},
+        .abilityNum = 1,
         .otId = 46285,
         .conditions = {5, 5, 5, 5, 30},
-        .personality = 0x7F,
+        .personality = 0x8C, // MODEST
         .heldItem = ITEM_WAVE_MAIL,
         .mailNum = 1,
         .otName = _("SKYLAR"),
@@ -1032,21 +1032,37 @@ static const struct InGameTrade sIngameTrades[] =
         .sheen = 10,
         .requestedSpecies = SPECIES_BAGON
     },
-    [INGAME_TRADE_MEOWTH] =
+    [INGAME_TRADE_EEVEE] =
     {
-        .nickname = _("MEOWOW"),
-        .species = SPECIES_MEOWTH,
-        .ivs = {4, 5, 4, 5, 4, 4},
+        .nickname = _("EVE"),
+        .species = SPECIES_EEVEE,
+        .ivs = {21, 21, 21, 21, 21, 21},
         .abilityNum = 0,
         .otId = 91481,
         .conditions = {5, 5, 5, 30, 5},
-        .personality = 0x8B,
+        .personality = 0x8F,  // BASHFUL
         .heldItem = ITEM_RETRO_MAIL,
         .mailNum = 2,
         .otName = _("ISIS"),
         .otGender = FEMALE,
         .sheen = 10,
         .requestedSpecies = SPECIES_SKITTY
+    },
+    [INGAME_TRADE_AERODACTYL] =
+    {
+        .nickname = _("AEROY"),
+        .species = SPECIES_AERODACTYL,
+        .ivs = {21, 23, 21, 24, 19, 15},
+        .abilityNum = 0,
+        .otId = 10920,
+        .conditions = {5, 5, 5, 30, 5},
+        .personality = 0x8A, // Jolly
+        .heldItem = ITEM_THICK_CLUB,
+        .mailNum = 2,
+        .otName = _("ROBERT"),
+        .otGender = MALE,
+        .sheen = 10,
+        .requestedSpecies = SPECIES_CHANSEY
     }
 };
 


### PR DESCRIPTION
## What
Revise in-game trades to feature more distinctive Pokémon. The initial trades often yielded Pokémon readily available in the wild, diminishing their uniqueness and importance.

### Before
| Takes      |  Gives|
| ----------- | ----------- |
| Ralts    | Seedot       |
| Volbeat   | Plusle        |
| Bagon   | Horsea        |
| Skitty   | Meowth        |

### After

| Takes      | Gives |
| ----------- | ----------- |
|  Seedot  | Farfetch'd  |
|   Abra | Mr. Mime        |
| Bagon   | Togepi        |
| Skitty   | Eevee        |
| Chansey   | Aerodactyl        |